### PR TITLE
Added virtualenv activation instruction for Windows users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
     - After cloning, change into the directory and type <code>virtualenv .</code>. This will then set up a a virtual python environment within that directory.
 
-    - Next, type <code>source bin/activate</code>. You should see that your command prompt has changed to the name of the folder. This means that you can install packages in here without affecting affecting files outside. To deactivate, type <code>deactivate</code>
+    - Next, type <code>source bin/activate</code> (if you are on MacOS or Linux) or <code>Scripts/activate</code> (if you are on Windows). You should see that your command prompt has changed to the name of the folder. This means that you can install packages in here without affecting affecting files outside. To deactivate, type <code>deactivate</code> regardless of your OS.
 
     - Rather than hunting around for the packages you need, you can install in one step. Type <code>pip install -r requirements.txt</code>. This will install all the packages listed in the respective file. If you install a package, make sure others know by updating the requirements.txt file. An easy way to do this is <code>pip freeze > requirements.txt</code>
 


### PR DESCRIPTION
The initial README only specified the virtualenv activation command for MacOS/Linux users. This instruction can't work for Windows users.