### PR TITLE
Error/ handle unknown email error by displaying flash message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ lib
 tests/
 .envrc
 __pycache__
+pyvenv.cfg
+.virtualenv
+.venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,14 @@
 click==7.1.2
+coverage==7.6.4
+exceptiongroup==1.2.2
 Flask==1.1.2
+iniconfig==2.0.0
 itsdangerous==1.1.0
 Jinja2==2.11.2
 MarkupSafe==1.1.1
+packaging==24.1
+pluggy==1.5.0
+pytest==8.3.3
+pytest-cov==6.0.0
+tomli==2.0.2
 Werkzeug==1.0.1

--- a/server.py
+++ b/server.py
@@ -1,17 +1,17 @@
 import json
-from flask import Flask,render_template,request,redirect,flash,url_for
+from flask import Flask, render_template, request, redirect, flash, url_for
 
 
 def loadClubs():
     with open('clubs.json') as c:
-         listOfClubs = json.load(c)['clubs']
-         return listOfClubs
+        listOfClubs = json.load(c)['clubs']
+        return listOfClubs
 
 
 def loadCompetitions():
     with open('competitions.json') as comps:
-         listOfCompetitions = json.load(comps)['competitions']
-         return listOfCompetitions
+        listOfCompetitions = json.load(comps)['competitions']
+        return listOfCompetitions
 
 
 app = Flask(__name__)
@@ -20,14 +20,26 @@ app.secret_key = 'something_special'
 competitions = loadCompetitions()
 clubs = loadClubs()
 
+
 @app.route('/')
 def index():
     return render_template('index.html')
 
-@app.route('/showSummary',methods=['POST'])
+
+@app.route('/showSummary', methods=['POST'])
 def showSummary():
-    club = [club for club in clubs if club['email'] == request.form['email']][0]
-    return render_template('welcome.html',club=club,competitions=competitions)
+    try:
+        club = [
+            club for club in clubs
+            if club['email'] == request.form['email']
+        ][0]
+        return render_template(
+            'welcome.html', club=club, competitions=competitions
+        )
+
+    except IndexError:
+        flash("Sorry, that email wasn't found.")
+        return redirect(url_for('index'))
 
 
 @app.route('/book/<competition>/<club>')

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,7 +7,16 @@
 <body>
     <h1>Welcome to the GUDLFT Registration Portal!</h1>
     Please enter your secretary email to continue:
-    <form action="showSummary" method="post">
+    {% with messages = get_flashed_messages() %}
+      {% if messages %}
+        <ul>
+          {% for message in messages %}
+            <li>{{ message }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    {% endwith %}
+    <form action="{{ url_for('showSummary') }}" method="post">
         <label for="email">Email:</label>
         <input type="email" name="email" id=""/>
         <button type="submit">Enter</button>

--- a/tests/unit/test_show_summary.py
+++ b/tests/unit/test_show_summary.py
@@ -1,0 +1,34 @@
+import sys
+import os
+import pytest
+sys.path.insert(
+    0, os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '../../')
+    )
+)
+
+from server import app # noqa
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_show_summary_email_not_found(client):
+    response = client.post(
+        '/showSummary',
+        data={'email': 'unknown@example.com'},
+        follow_redirects=False
+    )
+
+    assert response.status_code == 302
+
+    with client.session_transaction() as session:
+        flashed_messages = session['_flashes']
+        assert any(
+            "Sorry, that email wasn't found." in message
+            for message in flashed_messages
+        )


### PR DESCRIPTION
This PR fixes a bug (#1) where the application crashed when a user entered an unrecognized email in the system. The fix includes:

- Handling the error with a try...except to capture the case where the email is not found.
- Displaying a flash message "Sorry, this email was not found." to inform the user.
- Test with pytest to verify that the error is handled correctly and the message is displayed.

Tested:

The fix has been tested using pytest to ensure that the flash message displays correctly and that the application does not crash in the event of an unknown email.

**Issue liée :** #1