### PR TITLE
Bug/ fix points redemption validation to prevent overspending

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ lib
 tests/
 .envrc
 __pycache__
+*pyvenv.cfg

--- a/server.py
+++ b/server.py
@@ -43,12 +43,28 @@ def book(competition,club):
 
 @app.route('/purchasePlaces',methods=['POST'])
 def purchasePlaces():
-    competition = [c for c in competitions if c['name'] == request.form['competition']][0]
+    competition = [
+        c for c in competitions
+        if c['name'] == request.form['competition']
+    ][0]
     club = [c for c in clubs if c['name'] == request.form['club']][0]
     placesRequired = int(request.form['places'])
-    competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-placesRequired
-    flash('Great-booking complete!')
-    return render_template('welcome.html', club=club, competitions=competitions)
+
+    if int(club['points']) < placesRequired:
+        flash("You do not have enough points to book that many places.")
+        return render_template(
+            'welcome.html', club=club, competitions=competitions
+        )
+
+    club['points'] = int(club['points']) - placesRequired
+
+    competition['numberOfPlaces'] = (
+        int(competition['numberOfPlaces']) - placesRequired
+    )
+    flash('Great - booking complete !')
+    return render_template(
+        'welcome.html', club=club, competitions=competitions
+    )
 
 
 # TODO: Add route for points display

--- a/tests/unit/test_purchase_places.py
+++ b/tests/unit/test_purchase_places.py
@@ -1,0 +1,35 @@
+import sys
+import os
+import pytest
+sys.path.insert(
+    0, os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '../../')
+    )
+)
+
+from server import app, clubs, competitions # noqa
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_purchase_places_not_enough_points(client):
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Spring Festival',
+        'club': 'Iron Temple',
+        'places': 5
+    })
+
+    assert b"You do not have enough points to book that many places." \
+           in response.data
+
+    club = next(c for c in clubs if c['name'] == 'Iron Temple')
+    competition = next(
+        c for c in competitions if c['name'] == 'Spring Festival'
+    )
+    assert str(club['points']) == "4"
+    assert str(competition['numberOfPlaces']) == "25"


### PR DESCRIPTION
This PR addresses a bug that allowed clubs to redeem more points than they had available, which led to negative point balances. With this fix:

- A validation check now ensures that clubs cannot book more places than their available points.
- An error message is displayed to the user if they try to redeem more points than they have, and the booking process is halted.
- Tests have been added to confirm that the validation logic works as expected, preventing overspending.

Linked Issue: #2 