### PR TITLE
Bug/ fix limit booking to 12 places per competition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ lib
 tests/
 .envrc
 __pycache__
+*pyvenv.cfg

--- a/server.py
+++ b/server.py
@@ -41,14 +41,29 @@ def book(competition,club):
         return render_template('welcome.html', club=club, competitions=competitions)
 
 
-@app.route('/purchasePlaces',methods=['POST'])
+@app.route('/purchasePlaces', methods=['POST'])
 def purchasePlaces():
-    competition = [c for c in competitions if c['name'] == request.form['competition']][0]
-    club = [c for c in clubs if c['name'] == request.form['club']][0]
-    placesRequired = int(request.form['places'])
-    competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-placesRequired
-    flash('Great-booking complete!')
-    return render_template('welcome.html', club=club, competitions=competitions)
+    competition = next(
+        (c for c in competitions if c['name'] == request.form['competition']),
+        None
+    )
+    club = next((c for c in clubs if c['name'] == request.form['club']), None)
+    places_required = int(request.form['places'])
+
+    if places_required > 12:
+        flash("You cannot book more than 12 places in a single competition.")
+        return render_template(
+            'welcome.html', club=club, competitions=competitions
+        ), 200
+
+    club['points'] = str(int(club['points']) - places_required)
+    competition['numberOfPlaces'] = str(
+        int(competition['numberOfPlaces']) - places_required
+    )
+    flash('Great - booking complete!')
+    return render_template(
+        'welcome.html', club=club, competitions=competitions
+        )
 
 
 # TODO: Add route for points display

--- a/tests/unit/test_purchase_places.py
+++ b/tests/unit/test_purchase_places.py
@@ -1,0 +1,48 @@
+import sys
+import os
+import pytest
+sys.path.insert(
+    0, os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '../../')
+    )
+)
+
+from server import app, clubs, competitions # noqa
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_purchase_places_exceeds_max_limit(client):
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Spring Festival',
+        'club': 'Simply Lift',
+        'places': 13
+    })
+
+    assert b"You cannot book more than 12 places in a single competition." \
+           in response.data
+
+    competition = next(
+        c for c in competitions if c['name'] == 'Spring Festival'
+    )
+    assert competition['numberOfPlaces'] == "25"
+
+
+def test_purchase_places_within_max_limit(client):
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Spring Festival',
+        'club': 'Simply Lift',
+        'places': 12
+    })
+
+    assert b"Great - booking complete!" in response.data
+
+    competition = next(
+        c for c in competitions if c['name'] == 'Spring Festival'
+    )
+    assert competition['numberOfPlaces'] == "13"


### PR DESCRIPTION
This PR introduces a limit that prevents clubs from booking more than 12 places in a single competition. If a club tries to book more than 12 places, they receive an error message, and the booking is not processed. Unit tests have been added to ensure this limit works as expected.

Linked Issue : #4