### PR TITLE
Feature/ Add public points display on index page and welcome page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ lib
 tests/
 .envrc
 __pycache__
+pyvenv.cfg

--- a/server.py
+++ b/server.py
@@ -22,12 +22,12 @@ clubs = loadClubs()
 
 @app.route('/')
 def index():
-    return render_template('index.html')
+    return render_template('index.html', clubs=clubs)
 
 @app.route('/showSummary',methods=['POST'])
 def showSummary():
     club = [club for club in clubs if club['email'] == request.form['email']][0]
-    return render_template('welcome.html',club=club,competitions=competitions)
+    return render_template('welcome.html',club=club,competitions=competitions, clubs=clubs)
 
 
 @app.route('/book/<competition>/<club>')

--- a/templates/_points_table.html
+++ b/templates/_points_table.html
@@ -1,0 +1,14 @@
+<!-- templates/_points_table.html -->
+<h2>Clubs Points Board</h2>
+<table border="1">
+    <tr>
+        <th>Club Name</th>
+        <th>Points</th>
+    </tr>
+    {% for club in clubs %}
+    <tr>
+        <td>{{ club['name'] }}</td>
+        <td>{{ club['points'] }}</td>
+    </tr>
+    {% endfor %}
+</table>

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,5 +12,7 @@
         <input type="email" name="email" id=""/>
         <button type="submit">Enter</button>
     </form>
+
+    {% include '_points_table.html' %}
 </body>
 </html>

--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -1,36 +1,39 @@
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Summary | GUDLFT Registration</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Summary | GUDLFT Registration</title>
 </head>
 <body>
-        <h2>Welcome, {{club['email']}} </h2><a href="{{url_for('logout')}}">Logout</a>
+  <h2>Welcome, {{club['email']}}</h2>
+  <a href="{{url_for('logout')}}">Logout</a>
 
-    {% with messages = get_flashed_messages()%}
+  {% include '_points_table.html' %}
+
+  {% with messages = get_flashed_messages() %}
     {% if messages %}
-        <ul>
-       {% for message in messages %}
-            <li>{{message}}</li>
+      <ul>
+        {% for message in messages %}
+          <li>{{message}}</li>
         {% endfor %}
-       </ul>
-    {% endif%}
-    Points available: {{club['points']}}
-    <h3>Competitions:</h3>
-    <ul>
-        {% for comp in competitions%}
-        <li>
-            {{comp['name']}}<br />
-            Date: {{comp['date']}}</br>
-            Number of Places: {{comp['numberOfPlaces']}}
-            {%if comp['numberOfPlaces']|int >0%}
-            <a href="{{ url_for('book',competition=comp['name'],club=club['name']) }}">Book Places</a>
-            {%endif%}
-        </li>
-        <hr />
-        {% endfor %}
-    </ul>
-    {%endwith%}
+      </ul>
+    {% endif %}
+  {% endwith %}
 
+  Points available: {{club['points']}}
+  <h3>Competitions:</h3>
+  <ul>
+    {% for comp in competitions %}
+      <li>
+        {{comp['name']}}<br />
+        Date: {{comp['date']}}</br>
+        Number of Places: {{comp['numberOfPlaces']}}
+        {% if comp['numberOfPlaces']|int > 0 %}
+          <a href="{{ url_for('book', competition=comp['name'], club=club['name']) }}">Book Places</a>
+        {% endif %}
+      </li>
+      <hr />
+    {% endfor %}
+  </ul>
 </body>
 </html>

--- a/tests/unit/test_points_display.py
+++ b/tests/unit/test_points_display.py
@@ -1,0 +1,37 @@
+import sys
+import os
+import pytest
+sys.path.insert(
+    0, os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '../../')
+    )
+)
+
+from server import app, clubs, competitions # noqa
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_points_display_on_index(client):
+    response = client.get('/')
+    assert response.status_code == 200
+
+    for club in clubs:
+        assert bytes(club['name'], 'utf-8') in response.data
+        assert bytes(club['points'], 'utf-8') in response.data
+
+
+def test_points_display_after_login(client):
+    response = client.post(
+        '/showSummary', data={'email': 'john@simplylift.co'}
+    )
+    assert response.status_code == 200
+
+    for club in clubs:
+        assert bytes(club['name'], 'utf-8') in response.data
+        assert bytes(club['points'], 'utf-8') in response.data


### PR DESCRIPTION
This PR introduces a public, read-only display of club points on the homepage (index.html) and the welcome page. The points board is visible without login, listing each club with its current points balance. This ensures transparency and easy access for users to see available club points.

Linked Issue : #7 