### PR TITLE
Bug/ prevent booking for past competitions and limit booking page access to future events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ lib
 tests/
 .envrc
 __pycache__
+pyvenv.cfg

--- a/server.py
+++ b/server.py
@@ -1,5 +1,6 @@
 import json
 from flask import Flask,render_template,request,redirect,flash,url_for
+from datetime import datetime
 
 
 def loadClubs():
@@ -31,14 +32,16 @@ def showSummary():
 
 
 @app.route('/book/<competition>/<club>')
-def book(competition,club):
-    foundClub = [c for c in clubs if c['name'] == club][0]
-    foundCompetition = [c for c in competitions if c['name'] == competition][0]
-    if foundClub and foundCompetition:
-        return render_template('booking.html',club=foundClub,competition=foundCompetition)
-    else:
-        flash("Something went wrong-please try again")
+def book(competition, club):
+    competition = next((c for c in competitions if c['name'] == competition), None)
+    club = next((c for c in clubs if c['name'] == club), None)
+
+    competition_date = datetime.strptime(competition['date'], "%Y-%m-%d %H:%M:%S")
+    if competition_date < datetime.now():
+        flash("You cannot book places for a past competition.")
         return render_template('welcome.html', club=club, competitions=competitions)
+
+    return render_template('booking.html', club=club, competition=competition)
 
 
 @app.route('/purchasePlaces',methods=['POST'])

--- a/tests/unit/test_purchase_places.py
+++ b/tests/unit/test_purchase_places.py
@@ -1,0 +1,34 @@
+import sys
+import os
+import pytest
+sys.path.insert(
+    0, os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '../../')
+    )
+)
+
+from server import app, clubs, competitions # noqa
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_book_past_competition(client):
+    competition = next(
+        c for c in competitions if c['name'] == 'Spring Festival'
+    )
+    competition['date'] = "2020-03-27 10:00:00"
+
+    response = client.get(
+        '/book/Spring Festival/Simply Lift', follow_redirects=True
+    )
+
+    assert b"You cannot book places for a past competition." in response.data
+
+    club = next(c for c in clubs if c['name'] == 'Simply Lift')
+    assert club['points'] == "13"
+    assert competition['numberOfPlaces'] == "25"


### PR DESCRIPTION
This PR adds a validation that prevents users from booking places in competitions that have already occurred. If a competition is in the past, an error message is displayed on the main page instead of the booking page. The booking page (booking.html) is only shown for upcoming competitions, ensuring that bookings can only be made for valid events.

Linked Issue : #5