### PR TITLE
fix: redirect index when wrong credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@ bin
 include
 lib
 .Python
-tests/
 .envrc
 __pycache__

--- a/server.py
+++ b/server.py
@@ -27,11 +27,14 @@ def index():
     return render_template('index.html')
 
 #display welcome page after connextion
-@app.route('/showSummary',methods=['POST'])
-def showSummary():
+@app.route('/show_summary',methods=['POST'])
+def show_summary():
     #look for the club in the list of clubs
-    club = [club for club in clubs if club['email'] == request.form['email']][0]
-    return render_template('welcome.html',club=club,competitions=competitions)
+    for club in clubs:
+        if club['email'] == request.form['email']:
+            return render_template('welcome.html',club=club,competitions=competitions)
+    flash("Wrong credentials, please retry", "error")
+    return redirect(url_for('index'))
 
 #display the booking page
 @app.route('/book/<competition>/<club>')

--- a/server.py
+++ b/server.py
@@ -1,35 +1,39 @@
 import json
 from flask import Flask,render_template,request,redirect,flash,url_for
 
-
+#load the clubs and competitions from the json files
 def loadClubs():
     with open('clubs.json') as c:
          listOfClubs = json.load(c)['clubs']
          return listOfClubs
 
-
+#load the clubs and competitions from the json files
 def loadCompetitions():
     with open('competitions.json') as comps:
          listOfCompetitions = json.load(comps)['competitions']
          return listOfCompetitions
 
 
-app = Flask(__name__)
-app.secret_key = 'something_special'
+app = Flask(__name__) #create the Flask app
+app.secret_key = 'something_special' #used to add a session flash
 
+#load the clubs and competitions
 competitions = loadCompetitions()
 clubs = loadClubs()
 
 @app.route('/')
 def index():
+    # user can connect from a form (by email)
     return render_template('index.html')
 
+#display welcome page after connextion
 @app.route('/showSummary',methods=['POST'])
 def showSummary():
+    #look for the club in the list of clubs
     club = [club for club in clubs if club['email'] == request.form['email']][0]
     return render_template('welcome.html',club=club,competitions=competitions)
 
-
+#display the booking page
 @app.route('/book/<competition>/<club>')
 def book(competition,club):
     foundClub = [c for c in clubs if c['name'] == club][0]
@@ -40,11 +44,14 @@ def book(competition,club):
         flash("Something went wrong-please try again")
         return render_template('welcome.html', club=club, competitions=competitions)
 
-
+#purchase places
 @app.route('/purchasePlaces',methods=['POST'])
 def purchasePlaces():
+    #look for the competition and the club in the list of clubs and competitions
     competition = [c for c in competitions if c['name'] == request.form['competition']][0]
+    #look for the club in the list of clubs
     club = [c for c in clubs if c['name'] == request.form['club']][0]
+    #check if there are enough places
     placesRequired = int(request.form['places'])
     competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-placesRequired
     flash('Great-booking complete!')

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,10 +7,19 @@
 <body>
     <h1>Welcome to the GUDLFT Registration Portal!</h1>
     Please enter your secretary email to continue:
-    <form action="showSummary" method="post">
+    <form action="show_summary" method="post">
         <label for="email">Email:</label>
         <input type="email" name="email" id=""/>
         <button type="submit">Enter</button>
     </form>
 </body>
+{% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+    <ul class="flashes">
+      {% for category, message in messages %}
+        <li class="{{ category }}">{{ message }}</li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+{% endwith %}
 </html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+import pytest
+from server import app
+
+@pytest.fixture(scope="module")
+def client():
+    """Fixture pour créer un client de test Flask"""
+    app.config["TESTING"] = True
+    app.config["SECRET_KEY"] = "test_secret"
+    with app.test_client() as client:
+        yield client
+
+
+@pytest.fixture(scope="function")
+def setup_data(monkeypatch):    
+    mock_competitions = [
+        {"name": "Competition 1", "numberOfPlaces": "20"},
+        {"name": "Competition 2", "numberOfPlaces": "5"}
+    ]
+    mock_clubs = [
+        {"name": "Club A", "email": "clubA@example.com", "points": "10"},
+        {"name": "Club B", "email": "clubB@example.com", "points": "3"}
+    ]
+
+    monkeypatch.setattr("server.competitions", mock_competitions)
+    monkeypatch.setattr("server.clubs", mock_clubs)
+
+    return mock_competitions, mock_clubs

--- a/tests/test_purchase_place.py
+++ b/tests/test_purchase_place.py
@@ -1,0 +1,40 @@
+import pytest
+
+def test_purchase_places_success(client, setup_data):
+    #TEST can purchase places
+    competitions, _ = setup_data
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Competition 1',
+        'club': 'Club A',
+        'places': '5'
+    })
+    
+    assert response.status_code == 200
+    assert b"Great-booking complete!" in response.data
+    assert int(competitions[0]['numberOfPlaces']) == 15
+
+def test_purchase_places_not_enough_places(client, setup_data):
+    #TEST cant buy if not enough places
+    competitions, _ = setup_data
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Competition 2',
+        'club': 'Club A',
+        'places': '10'
+    })
+    
+    assert response.status_code == 200
+    assert b"Not enough places available." in response.data
+    assert int(competitions[1]['numberOfPlaces']) == 5
+
+def test_purchase_places_more_than_12(client, setup_data):
+    #TEST cant buy more than 12 places
+    competitions, _ = setup_data
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Competition 1',
+        'club': 'Club A',
+        'places': '13'
+    })
+    
+    assert response.status_code == 200
+    assert b"You cannot book more than 12 places per competition." in response.data
+    assert int(competitions[0]['numberOfPlaces']) == 20

--- a/tests/test_purchase_place.py
+++ b/tests/test_purchase_place.py
@@ -22,7 +22,7 @@ def test_purchase_places_not_enough_places(client, setup_data):
         'places': '10'
     })
     
-    assert response.status_code == 200
+    assert response.status_code == 400
     assert b"Not enough places available." in response.data
     assert int(competitions[1]['numberOfPlaces']) == 5
 
@@ -35,6 +35,6 @@ def test_purchase_places_more_than_12(client, setup_data):
         'places': '13'
     })
     
-    assert response.status_code == 200
+    assert response.status_code == 400
     assert b"You cannot book more than 12 places per competition." in response.data
     assert int(competitions[0]['numberOfPlaces']) == 20


### PR DESCRIPTION
Fixed issue where entering an incorrect email caused a server error (500). 
Now, if no club matches the provided email, the user is redirected to the index page with a flash message: "Wrong credentials, please retry." 
This prevents crashes and improves user experience.
