### PR TITLE
Fix/issue #4/clubs shouldn't be able to book more than 12 places per competition

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -1,0 +1,2 @@
+FLASK_APP=server
+FLASK_ENV=development

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@ bin
 include
 lib
 .Python
-tests/
 .envrc
 __pycache__
+.venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,13 @@
 click==7.1.2
+colorama==0.4.6
 Flask==1.1.2
+iniconfig==2.3.0
 itsdangerous==1.1.0
 Jinja2==2.11.2
 MarkupSafe==1.1.1
+packaging==25.0
+pluggy==1.6.0
+Pygments==2.19.2
+pytest==8.4.2
+python-dotenv==1.1.1
 Werkzeug==1.0.1

--- a/server.py
+++ b/server.py
@@ -48,6 +48,7 @@ def book(competition,club):
 
 @app.route('/purchasePlaces',methods=['POST'])
 def purchasePlaces():
+    MAX_BOOKING = 12
     competition = [c for c in competitions if c['name'] == request.form['competition']][0]
     club = [c for c in clubs if c['name'] == request.form['club']][0]
     placesRequired = int(request.form['places'])
@@ -55,7 +56,12 @@ def purchasePlaces():
 
     if placesRequired > club_points:
         flash("Cannot book more places than club points.")
-        return render_template('welcome.html', club=club, competitions=competitions)    
+        return render_template('welcome.html', club=club, competitions=competitions) 
+
+
+    if placesRequired > MAX_BOOKING:
+        flash(f"Cannot book more than {MAX_BOOKING} places for this competition.")
+        return render_template('welcome.html', club=club, competitions=competitions)   
 
     competition['numberOfPlaces'] = int(competition['numberOfPlaces']) - placesRequired
     flash('Great - booking complete!')

--- a/server.py
+++ b/server.py
@@ -51,8 +51,14 @@ def purchasePlaces():
     competition = [c for c in competitions if c['name'] == request.form['competition']][0]
     club = [c for c in clubs if c['name'] == request.form['club']][0]
     placesRequired = int(request.form['places'])
-    competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-placesRequired
-    flash('Great-booking complete!')
+    club_points = int(club['points'])
+
+    if placesRequired > club_points:
+        flash("Cannot book more places than club points.")
+        return render_template('welcome.html', club=club, competitions=competitions)    
+
+    competition['numberOfPlaces'] = int(competition['numberOfPlaces']) - placesRequired
+    flash('Great - booking complete!')
     return render_template('welcome.html', club=club, competitions=competitions)
 
 

--- a/server.py
+++ b/server.py
@@ -26,8 +26,13 @@ def index():
 
 @app.route('/showSummary',methods=['POST'])
 def showSummary():
-    club = [club for club in clubs if club['email'] == request.form['email']][0]
-    return render_template('welcome.html',club=club,competitions=competitions)
+    email = request.form.get('email', '')
+    email = email.strip()
+    club = next((c for c in clubs if c.get('email', '').strip() == email), None)
+    if not email or not club:
+        flash("Sorry, that email was not found, please try again.")
+        return render_template('index.html')
+    return render_template('welcome.html', club=club, competitions=competitions)
 
 
 @app.route('/book/<competition>/<club>')

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,6 +7,15 @@
 <body>
     <h1>Welcome to the GUDLFT Registration Portal!</h1>
     Please enter your secretary email to continue:
+        {% with messages = get_flashed_messages() %}
+            {% if messages %}
+                <ul class="flashes" style="color: red;">
+                    {% for message in messages %}
+                        <li>{{ message }}</li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+        {% endwith %}
     <form action="showSummary" method="post">
         <label for="email">Email:</label>
         <input type="email" name="email" id=""/>

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import pytest
+
+
+"""Pytest configuration file to set up the testing environment.
+This file adds the project root directory to sys.path to ensure that
+"""
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from server import app
+
+@pytest.fixture
+def client():
+    """Flask test client fixture.
+    Provides a test client for the Flask application defined in server.py.
+    """
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client

--- a/tests/unit/test_book_more_than_12_places.py
+++ b/tests/unit/test_book_more_than_12_places.py
@@ -1,0 +1,47 @@
+import server
+
+"""
+Unit test file to check that clubs cannot book more than 12 places.
+
+Test 1: Club A has 13 points and competition 1 has 25 places.
+    - Book 12 places
+    - status code 200
+    - message: "Great - booking complete!"
+    - competition places decreased
+
+Test 2: Club A has 13 points and competition 1 has 25 places.
+    - Book 13 places
+    - status code 200
+    - message contains "Cannot book more than"
+    - competition places unchanged
+"""
+
+
+def test_book_12_places_allowed(client):
+    server.clubs = [{"name": "Club A", "points": "13"}]
+    server.competitions = [{"name": "Comp 1", "numberOfPlaces": "25"}]
+
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Comp 1',
+        'club': 'Club A',
+        'places': '12'
+    })
+
+    assert response.status_code == 200
+    assert b"Great - booking complete!" in response.data
+    assert int(server.competitions[0]['numberOfPlaces']) == 13
+
+
+def test_cannot_book_more_than_12_places(client):
+    server.clubs = [{"name": "Club A", "points": "13"}]
+    server.competitions = [{"name": "Comp 1", "numberOfPlaces": "25"}]
+
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Comp 1',
+        'club': 'Club A',
+        'places': '13'
+    })
+
+    assert response.status_code == 200
+    assert b"Cannot book more than" in response.data
+    assert int(server.competitions[0]['numberOfPlaces']) == 25

--- a/tests/unit/test_book_place_with_enough_point.py
+++ b/tests/unit/test_book_place_with_enough_point.py
@@ -1,0 +1,44 @@
+import server
+
+"""
+Unit test file for the place booking feature.
+The purpose is to verify that booking places is only possible with sufficient points.
+
+Test 1: the club has 4 points and wants to book 4 places — booking accepted :
+    - status code 200
+    - confirmation message
+    - remaining places updated correctly.
+Test 2: the club has 4 points and wants to book 5 places — booking refused :
+    - status code 200
+    - error message
+    - remaining places unchanged
+"""
+
+
+def test_book_places_with_enough_points(client):
+    server.clubs = [{"name": "Club A", "points": "4"}]
+    server.competitions = [{"name": "Comp 1", "numberOfPlaces": "5"}]
+
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Comp 1',
+        'club': 'Club A',
+        'places': '4'
+    })
+
+    assert response.status_code == 200
+    assert b"Great - booking complete!" in response.data
+    assert int(server.competitions[0]['numberOfPlaces']) == 1
+
+def test_book_places_without_enough_points(client):
+    server.clubs = [{"name": "Club B", "points": "4"}]
+    server.competitions = [{"name": "Comp 2", "numberOfPlaces": "5"}]
+
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Comp 2',
+        'club': 'Club B',
+        'places': '5'
+    })
+
+    assert response.status_code == 200
+    assert b"Cannot book more places than club points." in response.data
+    assert int(server.competitions[0]['numberOfPlaces']) == 5

--- a/tests/unit/test_check_email_show_summary.py
+++ b/tests/unit/test_check_email_show_summary.py
@@ -1,0 +1,27 @@
+import pytest
+
+
+"""Unit tests for the /showSummary route in server.py.
+test1 : Valid email should return 200 and welcome message
+test2 : Unknown email should return 200 and error message
+test3 : Invalid email (empty or whitespace) should return 200 and error message
+
+"""
+
+
+def test_show_summary_with_valid_email(client):
+    response = client.post('/showSummary', data={'email': 'john@simplylift.co'})
+    assert response.status_code == 200
+    assert b'Welcome' in response.data
+
+
+def test_show_summary_with_unknown_email(client):
+    response = client.post('/showSummary', data={'email': 'unknown@example.com'})
+    assert response.status_code == 200
+    assert b"Sorry, that email was not found" in response.data
+
+
+def test_show_summary_with_invalid_email(client):
+    response = client.post('/showSummary', data={'email': '   '})
+    assert response.status_code == 200
+    assert b"Sorry, that email was not found" in response.data


### PR DESCRIPTION
## Summary

This pull request fixes **Issue #4 ** — clubs are not allowed to book more than 12 places per competition.

## Context

The `purchasePlaces()` function in `server.py` did not restrict the number of places a club could book
A limit of 12 places per competition is now enforced to to ensure fairness toward other clubs

## Changes Made

- **server.py** → added a condition in `purchasePlaces()` to restrict bookings to a maximum of 12 places  
- **tests/test_max_booking_limit.py** → created a new test file to check `purchasePlaces()` behaviour when clubs try to book 12 and/or more than 12 places.


## Testing

- 2 tests run successfully using `pytest`
- Verified status code, message and number of places remaining in the browser for: 
   - booking 12 places
   - booking more than 12 places


## Linked Issue

Fix #4