### PR TITLE
Fix/cumulative booking limit

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -1,0 +1,2 @@
+FLASK_APP=server
+FLASK_ENV=development

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@ bin
 include
 lib
 .Python
-tests/
 .envrc
 __pycache__
+.venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,13 @@
 click==7.1.2
+colorama==0.4.6
 Flask==1.1.2
+iniconfig==2.3.0
 itsdangerous==1.1.0
 Jinja2==2.11.2
 MarkupSafe==1.1.1
+packaging==25.0
+pluggy==1.6.0
+Pygments==2.19.2
+pytest==8.4.2
+python-dotenv==1.1.1
 Werkzeug==1.0.1

--- a/server.py
+++ b/server.py
@@ -88,10 +88,13 @@ def purchasePlaces():
         flash("Cannot book more places than available.")
         return render_template('welcome.html', club=club, competitions=competitions)
 
-    if placesRequired > MAX_BOOKING:
-        flash(f"Cannot book more than {MAX_BOOKING} places for this competition.")
-        return render_template('welcome.html', club=club, competitions=competitions)   
+    already_booked = int(competition.get('booked_by', {}).get(club['name'], 0))
 
+    if placesRequired > MAX_BOOKING or already_booked + placesRequired > MAX_BOOKING:
+        flash(f"Cannot book more than {MAX_BOOKING} places per club for this competition.")
+        return render_template('welcome.html', club=club, competitions=competitions)
+
+    competition.setdefault('booked_by', {})[club['name']] = already_booked + placesRequired
     competition['numberOfPlaces'] = int(competition['numberOfPlaces']) - placesRequired
     club['points'] = club_points - placesRequired
     flash('Great - booking complete!')

--- a/server.py
+++ b/server.py
@@ -1,5 +1,6 @@
 import json
 from flask import Flask,render_template,request,redirect,flash,url_for
+from datetime import datetime
 
 
 def loadClubs():
@@ -39,8 +40,15 @@ def showSummary():
 def book(competition,club):
     foundClub = [c for c in clubs if c['name'] == club][0]
     foundCompetition = [c for c in competitions if c['name'] == competition][0]
+    
+    competition_date = datetime.strptime(foundCompetition['date'], "%Y-%m-%d %H:%M:%S")
+    if competition_date < datetime.now():
+        flash("This competition has already taken place, booking is not allowed.")
+        return render_template('welcome.html', club=foundClub, competitions=competitions)
+
     if foundClub and foundCompetition:
         return render_template('booking.html',club=foundClub,competition=foundCompetition)
+    
     else:
         flash("Something went wrong-please try again")
         return render_template('welcome.html', club=club, competitions=competitions)

--- a/server.py
+++ b/server.py
@@ -72,6 +72,7 @@ def purchasePlaces():
         return render_template('welcome.html', club=club, competitions=competitions)   
 
     competition['numberOfPlaces'] = int(competition['numberOfPlaces']) - placesRequired
+    club['points'] = club_points - placesRequired
     flash('Great - booking complete!')
     return render_template('welcome.html', club=club, competitions=competitions)
 

--- a/server.py
+++ b/server.py
@@ -48,6 +48,7 @@ def book(competition,club):
 
 @app.route('/purchasePlaces',methods=['POST'])
 def purchasePlaces():
+    MAX_BOOKING = 12
     competition = [c for c in competitions if c['name'] == request.form['competition']][0]
     club = [c for c in clubs if c['name'] == request.form['club']][0]
     placesRequired = int(request.form['places'])
@@ -55,7 +56,12 @@ def purchasePlaces():
 
     if placesRequired > club_points:
         flash("Cannot book more places than club points.")
-        return render_template('welcome.html', club=club, competitions=competitions)    
+        return render_template('welcome.html', club=club, competitions=competitions) 
+
+
+    if placesRequired > MAX_BOOKING:
+        flash(f"Cannot book more than {MAX_BOOKING} places for this competition.")
+        return render_template('welcome.html', club=club, competitions=competitions)   
 
     competition['numberOfPlaces'] = int(competition['numberOfPlaces']) - placesRequired
     flash('Great - booking complete!')

--- a/server.py
+++ b/server.py
@@ -51,8 +51,14 @@ def purchasePlaces():
     competition = [c for c in competitions if c['name'] == request.form['competition']][0]
     club = [c for c in clubs if c['name'] == request.form['club']][0]
     placesRequired = int(request.form['places'])
-    competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-placesRequired
-    flash('Great-booking complete!')
+    club_points = int(club['points'])
+
+    if placesRequired > club_points:
+        flash("Cannot book more places than club points.")
+        return render_template('welcome.html', club=club, competitions=competitions)    
+
+    competition['numberOfPlaces'] = int(competition['numberOfPlaces']) - placesRequired
+    flash('Great - booking complete!')
     return render_template('welcome.html', club=club, competitions=competitions)
 
 

--- a/server.py
+++ b/server.py
@@ -26,8 +26,13 @@ def index():
 
 @app.route('/showSummary',methods=['POST'])
 def showSummary():
-    club = [club for club in clubs if club['email'] == request.form['email']][0]
-    return render_template('welcome.html',club=club,competitions=competitions)
+    email = request.form.get('email', '')
+    email = email.strip()
+    club = next((c for c in clubs if c.get('email', '').strip() == email), None)
+    if not email or not club:
+        flash("Sorry, that email was not found, please try again.")
+        return render_template('index.html')
+    return render_template('welcome.html', club=club, competitions=competitions)
 
 
 @app.route('/book/<competition>/<club>')

--- a/server.py
+++ b/server.py
@@ -59,8 +59,26 @@ def purchasePlaces():
     MAX_BOOKING = 12
     competition = [c for c in competitions if c['name'] == request.form['competition']][0]
     club = [c for c in clubs if c['name'] == request.form['club']][0]
-    placesRequired = int(request.form['places'])
+
+    places = request.form.get('places')
+    if not places:
+        flash("Please enter a number of places.")
+        return render_template('welcome.html', club=club, competitions=competitions)
+
+    # même si on a vérifié dans le formulaire sur le HTML avec un input de type "number",
+    # on doit quand même gérer le cas où un utilisateur malveillant envoie une valeur non numérique
+    # en modifiant via les outils de développement du navigateur. 
+    try:
+        placesRequired = int(places)
+    except ValueError:
+        flash("Invalid number of places.")
+        return render_template('welcome.html', club=club, competitions=competitions)
+
     club_points = int(club['points'])
+
+    if placesRequired <= 0:
+        flash("Invalid number of places.")
+        return render_template('welcome.html', club=club, competitions=competitions)
 
     if placesRequired > club_points:
         flash("Cannot book more places than club points.")

--- a/server.py
+++ b/server.py
@@ -23,7 +23,7 @@ clubs = loadClubs()
 
 @app.route('/')
 def index():
-    return render_template('index.html')
+    return render_template('index.html', clubs=clubs)
 
 @app.route('/showSummary',methods=['POST'])
 def showSummary():

--- a/server.py
+++ b/server.py
@@ -84,6 +84,9 @@ def purchasePlaces():
         flash("Cannot book more places than club points.")
         return render_template('welcome.html', club=club, competitions=competitions) 
 
+    if placesRequired > int(competition['numberOfPlaces']):
+        flash("Cannot book more places than available.")
+        return render_template('welcome.html', club=club, competitions=competitions)
 
     if placesRequired > MAX_BOOKING:
         flash(f"Cannot book more than {MAX_BOOKING} places for this competition.")

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,6 +7,15 @@
 <body>
     <h1>Welcome to the GUDLFT Registration Portal!</h1>
     Please enter your secretary email to continue:
+        {% with messages = get_flashed_messages() %}
+            {% if messages %}
+                <ul class="flashes" style="color: red;">
+                    {% for message in messages %}
+                        <li>{{ message }}</li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+        {% endwith %}
     <form action="showSummary" method="post">
         <label for="email">Email:</label>
         <input type="email" name="email" id=""/>

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,5 +21,22 @@
         <input type="email" name="email" id=""/>
         <button type="submit">Enter</button>
     </form>
+    <h2>Clubs Points Summary</h2>
+<table style="border-collapse: collapse; width: 30%; background-color: #f5f5f5; color: #333;">
+    <thead>
+        <tr style="background-color: #e0e0e0;">
+            <th style="border: 1px solid #ccc; padding: 6px;">Club</th>
+            <th style="border: 1px solid #ccc; padding: 6px;">Points</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for club in clubs %}
+        <tr style="text-align: center;">
+            <td style="border: 1px solid #ccc; padding: 6px;">{{ club['name'] }}</td>
+            <td style="border: 1px solid #ccc; padding: 6px;">{{ club['points'] }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
 </body>
 </html>

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import pytest
+
+
+"""Pytest configuration file to set up the testing environment.
+This file adds the project root directory to sys.path to ensure that
+"""
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from server import app
+
+@pytest.fixture
+def client():
+    """Flask test client fixture.
+    Provides a test client for the Flask application defined in server.py.
+    """
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client

--- a/tests/unit/test_board_with_clubs_and_their_points.py
+++ b/tests/unit/test_board_with_clubs_and_their_points.py
@@ -1,0 +1,21 @@
+import server
+
+"""
+Unit test file to check if the index page displays the clubs and their points correctly
+Test 1: The page loads successfully (status code 200)
+Test 2: Each club name and its points appear in the HTML
+"""
+
+def test_index_page_loads(client):
+    response = client.get('/')
+    assert response.status_code == 200
+    assert b"Clubs Points Summary" in response.data
+
+
+def test_index_page_displays_clubs_points(client):
+    response = client.get('/')
+    data = response.data.decode()
+
+    for club in server.clubs:
+        assert club["name"] in data
+        assert club["points"] in data

--- a/tests/unit/test_book_more_than_12_places.py
+++ b/tests/unit/test_book_more_than_12_places.py
@@ -1,0 +1,47 @@
+import server
+
+"""
+Unit test file to check that clubs cannot book more than 12 places.
+
+Test 1: Club A has 13 points and competition 1 has 25 places.
+    - Book 12 places
+    - status code 200
+    - message: "Great - booking complete!"
+    - competition places decreased
+
+Test 2: Club A has 13 points and competition 1 has 25 places.
+    - Book 13 places
+    - status code 200
+    - message contains "Cannot book more than"
+    - competition places unchanged
+"""
+
+
+def test_book_12_places_allowed(client):
+    server.clubs = [{"name": "Club A", "points": "13"}]
+    server.competitions = [{"name": "Comp 1", "numberOfPlaces": "25"}]
+
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Comp 1',
+        'club': 'Club A',
+        'places': '12'
+    })
+
+    assert response.status_code == 200
+    assert b"Great - booking complete!" in response.data
+    assert int(server.competitions[0]['numberOfPlaces']) == 13
+
+
+def test_cannot_book_more_than_12_places(client):
+    server.clubs = [{"name": "Club A", "points": "13"}]
+    server.competitions = [{"name": "Comp 1", "numberOfPlaces": "25"}]
+
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Comp 1',
+        'club': 'Club A',
+        'places': '13'
+    })
+
+    assert response.status_code == 200
+    assert b"Cannot book more than" in response.data
+    assert int(server.competitions[0]['numberOfPlaces']) == 25

--- a/tests/unit/test_book_more_than_12_places.py
+++ b/tests/unit/test_book_more_than_12_places.py
@@ -1,19 +1,12 @@
 import server
 
 """
-Unit test file to check that clubs cannot book more than 12 places.
+Unit test file to check that clubs cannot book more than 12 places in total.
 
-Test 1: Club A has 13 points and competition 1 has 25 places.
-    - Book 12 places
-    - status code 200
-    - message: "Great - booking complete!"
-    - competition places decreased
-
-Test 2: Club A has 13 points and competition 1 has 25 places.
-    - Book 13 places
-    - status code 200
-    - message contains "Cannot book more than"
-    - competition places unchanged
+Test 1: Club A books exactly 12 places -> success
+Test 2: Club A tries to book 13 places -> rejected
+Test 3: Club A has already booked 6 places, tries to book 7 more -> rejected (cumulative > 12)
+Test 4: Club A has already booked 6 places, tries to book 5 more -> accepted (cumulative = 11)
 """
 
 
@@ -45,3 +38,44 @@ def test_cannot_book_more_than_12_places(client):
     assert response.status_code == 200
     assert b"Cannot book more than" in response.data
     assert int(server.competitions[0]['numberOfPlaces']) == 25
+
+
+def test_cannot_exceed_12_places_cumulatively(client):
+    server.clubs = [{"name": "Club A", "points": "13"}]
+    server.competitions = [{
+        "name": "Comp 1",
+        "numberOfPlaces": "25",
+        "booked_by": {"Club A": 6}
+    }]
+
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Comp 1',
+        'club': 'Club A',
+        'places': '7'
+    })
+
+    assert response.status_code == 200
+    assert b"Cannot book more than" in response.data
+    assert int(server.competitions[0]['numberOfPlaces']) == 25
+    assert int(server.clubs[0]['points']) == 13
+
+
+def test_booking_allowed_when_cumulative_under_limit(client):
+    server.clubs = [{"name": "Club A", "points": "13"}]
+    server.competitions = [{
+        "name": "Comp 1",
+        "numberOfPlaces": "25",
+        "booked_by": {"Club A": 6}
+    }]
+
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Comp 1',
+        'club': 'Club A',
+        'places': '5'
+    })
+
+    assert response.status_code == 200
+    assert b"Great - booking complete!" in response.data
+    assert int(server.competitions[0]['numberOfPlaces']) == 20
+    assert int(server.clubs[0]['points']) == 8
+    assert server.competitions[0]['booked_by']['Club A'] == 11

--- a/tests/unit/test_book_more_than_places_available.py
+++ b/tests/unit/test_book_more_than_places_available.py
@@ -1,0 +1,20 @@
+import server
+
+"""
+Unit test to verify that users cannot book more places than available.
+"""
+
+def test_booking_more_places_than_available(client):
+    server.clubs = [{"name": "Club A", "points": "20"}]
+    server.competitions = [{"name": "Comp 1", "numberOfPlaces": "5"}]
+
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Comp 1',
+        'club': 'Club A',
+        'places': '10'
+    })
+
+    assert response.status_code == 200
+    assert b"Cannot book more places than available." in response.data
+    assert int(server.competitions[0]['numberOfPlaces']) == 5
+    assert int(server.clubs[0]['points']) == 20

--- a/tests/unit/test_book_past_competition.py
+++ b/tests/unit/test_book_past_competition.py
@@ -1,0 +1,34 @@
+import server
+from datetime import datetime, timedelta
+
+"""
+Unit test file to check that booking is not allowed for past competitions
+
+Test 1: A competition in the future -> user can access booking page
+    - status code 200
+    - page contains "How many places?"
+Test 2: A competition in the past -> booking is refused.
+    - status code 200
+    - message contains "This competition has already taken place"
+"""
+
+def test_can_book_future_competition(client):
+    future_date = (datetime.now() + timedelta(days=5)).strftime("%Y-%m-%d %H:%M:%S")
+    server.competitions = [{"name": "Future Comp", "date": future_date, "numberOfPlaces": "10"}]
+    server.clubs = [{"name": "Club A", "email": "a@a.com", "points": "10"}]
+
+    response = client.get('/book/Future Comp/Club A')
+
+    assert response.status_code == 200
+    assert b"How many places?" in response.data
+
+
+def test_cannot_book_past_competition(client):
+    past_date = (datetime.now() - timedelta(days=5)).strftime("%Y-%m-%d %H:%M:%S")
+    server.competitions = [{"name": "Old Comp", "date": past_date, "numberOfPlaces": "10"}]
+    server.clubs = [{"name": "Club A", "email": "a@a.com", "points": "10"}]
+
+    response = client.get('/book/Old Comp/Club A')
+
+    assert response.status_code == 200
+    assert b"This competition has already taken place" in response.data

--- a/tests/unit/test_book_place_with_enough_point.py
+++ b/tests/unit/test_book_place_with_enough_point.py
@@ -1,0 +1,44 @@
+import server
+
+"""
+Unit test file for the place booking feature.
+The purpose is to verify that booking places is only possible with sufficient points.
+
+Test 1: the club has 4 points and wants to book 4 places — booking accepted :
+    - status code 200
+    - confirmation message
+    - remaining places updated correctly.
+Test 2: the club has 4 points and wants to book 5 places — booking refused :
+    - status code 200
+    - error message
+    - remaining places unchanged
+"""
+
+
+def test_book_places_with_enough_points(client):
+    server.clubs = [{"name": "Club A", "points": "4"}]
+    server.competitions = [{"name": "Comp 1", "numberOfPlaces": "5"}]
+
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Comp 1',
+        'club': 'Club A',
+        'places': '4'
+    })
+
+    assert response.status_code == 200
+    assert b"Great - booking complete!" in response.data
+    assert int(server.competitions[0]['numberOfPlaces']) == 1
+
+def test_book_places_without_enough_points(client):
+    server.clubs = [{"name": "Club B", "points": "4"}]
+    server.competitions = [{"name": "Comp 2", "numberOfPlaces": "5"}]
+
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Comp 2',
+        'club': 'Club B',
+        'places': '5'
+    })
+
+    assert response.status_code == 200
+    assert b"Cannot book more places than club points." in response.data
+    assert int(server.competitions[0]['numberOfPlaces']) == 5

--- a/tests/unit/test_booking_decrease_club_points.py
+++ b/tests/unit/test_booking_decrease_club_points.py
@@ -1,0 +1,27 @@
+import server
+
+"""
+Unit test file to verify that club points are correctly updated after booking.
+
+Test 1: Club has 10 points, books 3 places, points should decrease by 3.
+    - status code 200
+    - success message "Great - booking complete!"
+    - club points decrease by 3
+
+"""
+
+
+def test_club_points_decrease_after_booking(client):
+    server.clubs = [{"name": "Club A", "points": "10"}]
+    server.competitions = [{"name": "Comp 1", "numberOfPlaces": "20"}]
+
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Comp 1',
+        'club': 'Club A',
+        'places': '3'
+    })
+
+    assert response.status_code == 200
+    assert b"Great - booking complete!" in response.data
+    assert int(server.clubs[0]['points']) == 7  
+

--- a/tests/unit/test_check_email_show_summary.py
+++ b/tests/unit/test_check_email_show_summary.py
@@ -1,0 +1,27 @@
+import pytest
+
+
+"""Unit tests for the /showSummary route in server.py.
+test1 : Valid email should return 200 and welcome message
+test2 : Unknown email should return 200 and error message
+test3 : Invalid email (empty or whitespace) should return 200 and error message
+
+"""
+
+
+def test_show_summary_with_valid_email(client):
+    response = client.post('/showSummary', data={'email': 'john@simplylift.co'})
+    assert response.status_code == 200
+    assert b'Welcome' in response.data
+
+
+def test_show_summary_with_unknown_email(client):
+    response = client.post('/showSummary', data={'email': 'unknown@example.com'})
+    assert response.status_code == 200
+    assert b"Sorry, that email was not found" in response.data
+
+
+def test_show_summary_with_invalid_email(client):
+    response = client.post('/showSummary', data={'email': '   '})
+    assert response.status_code == 200
+    assert b"Sorry, that email was not found" in response.data

--- a/tests/unit/test_invalid_number_of_places_booking.py
+++ b/tests/unit/test_invalid_number_of_places_booking.py
@@ -1,0 +1,90 @@
+import server
+
+"""
+Unit test file to verify that the booking system correctly handles invalid number of places inputs
+
+Test 1: booking with valid number of places -> success, points and places updated
+Test 2 :booking with 0 places -> error message, number of places and points unchanged
+Test 3: booking with negative places -> error message, number of places and points unchanged
+Test 4: booking without providing number of places -> error message, number of places and points unchanged
+Test 5: booking with non-numeric input -> error message, number of places and points unchanged
+"""
+
+def test_booking_valid_number_of_places(client):
+    server.clubs = [{"name": "Club A", "points": "10"}]
+    server.competitions = [{"name": "Comp 1", "numberOfPlaces": "20"}]
+
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Comp 1',
+        'club': 'Club A',
+        'places': '3'
+    })
+
+    assert response.status_code == 200
+    assert b"Great - booking complete!" in response.data
+    assert int(server.clubs[0]['points']) == 7
+    assert int(server.competitions[0]['numberOfPlaces']) == 17
+
+
+def test_booking_zero_places(client):
+    server.clubs = [{"name": "Club A", "points": "10"}]
+    server.competitions = [{"name": "Comp 1", "numberOfPlaces": "20"}]
+
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Comp 1',
+        'club': 'Club A',
+        'places': '0'
+    })
+
+    assert response.status_code == 200
+    assert b"Invalid number of places." in response.data
+    assert int(server.competitions[0]['numberOfPlaces']) == 20
+    assert int(server.clubs[0]['points']) == 10
+
+
+def test_booking_negative_places(client):
+    server.clubs = [{"name": "Club A", "points": "10"}]
+    server.competitions = [{"name": "Comp 1", "numberOfPlaces": "20"}]
+
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Comp 1',
+        'club': 'Club A',
+        'places': '-5'
+    })
+
+    assert response.status_code == 200
+    assert b"Invalid number of places." in response.data
+    assert int(server.competitions[0]['numberOfPlaces']) == 20
+    assert int(server.clubs[0]['points']) == 10
+
+
+def test_booking_without_places_value(client):
+    server.clubs = [{"name": "Club A", "points": "10"}]
+    server.competitions = [{"name": "Comp 1", "numberOfPlaces": "20"}]
+
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Comp 1',
+        'club': 'Club A',
+        'places': ''
+    })
+
+    assert response.status_code == 200
+    assert b"Please enter a number of places." in response.data
+    assert int(server.competitions[0]['numberOfPlaces']) == 20
+    assert int(server.clubs[0]['points']) == 10
+
+
+def test_booking_with_non_numeric_input(client):
+    server.clubs = [{"name": "Club A", "points": "10"}]
+    server.competitions = [{"name": "Comp 1", "numberOfPlaces": "20"}]
+
+    response = client.post('/purchasePlaces', data={
+        'competition': 'Comp 1',
+        'club': 'Club A',
+        'places': 'abc'
+    })
+
+    assert response.status_code == 200
+    assert b"Invalid number of places." in response.data
+    assert int(server.competitions[0]['numberOfPlaces']) == 20
+    assert int(server.clubs[0]['points']) == 10


### PR DESCRIPTION
## Context

Currently, a club cannot book more than 12 places in a single reservation, BUT it can still exceed this limit by making several smaller bookings
for exemple, he can book 6 + 7 = 13 total places

## Changes Made

server.py -> Update `pruchasePlaces` and combined single-booking and cumulative limit validation to 12
test/unit/test_book_more_than_12_places.py -> update the file to add 2 more tests

## Testing
- 2 tests pass successfully using pytest :
   - a test to try to book 7 more places after alredy booked 6 -> failed
   - a test to try to book 5 more places after alredy booked 6 -> succeeded
