### PR TITLE
Feature : add signup page and password in authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ lib
 tests/
 .envrc
 __pycache__
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ lib
 .envrc
 __pycache__
 .idea/
+.coverage

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ bin
 include
 lib
 .Python
-tests/
 .envrc
 __pycache__
 .idea/

--- a/clubs.json
+++ b/clubs.json
@@ -11,6 +11,6 @@
     },
     {   "name":"She Lifts",
         "email": "kate@shelifts.co.uk",
-        "points":"12"
+        "points":"15"
     }
 ]}

--- a/clubs.json
+++ b/clubs.json
@@ -1,11 +1,6 @@
 {
     "clubs": [
         {
-            "name": "Simply Lift",
-            "email": "john@simplylift.co",
-            "points": "13"
-        },
-        {
             "name": "She Lifts",
             "email": "kate@shelifts.co.uk",
             "points": "12"
@@ -14,6 +9,11 @@
             "name": "Iron Temple",
             "email": "admin@irontemple.com",
             "points": "4"
+        },
+        {
+            "name": "Simply Lift",
+            "email": "john@simplylift.co",
+            "points": "13"
         }
     ]
 }

--- a/clubs.json
+++ b/clubs.json
@@ -13,7 +13,7 @@
         {
             "name": "Iron Temple",
             "email": "admin@irontemple.com",
-            "points": "5"
+            "points": "3"
         }
     ]
 }

--- a/clubs.json
+++ b/clubs.json
@@ -13,7 +13,7 @@
         {
             "name": "Iron Temple",
             "email": "admin@irontemple.com",
-            "points": "4"
+            "points": "5"
         }
     ]
 }

--- a/clubs.json
+++ b/clubs.json
@@ -3,22 +3,26 @@
         {
             "name": "Simply Lift",
             "email": "john@simplylift.co",
+            "password": "pbkdf2:sha256:150000$eHVGmFVY$00afed3d5a39621cc5aad05d069b8d8643c9e3e47435471f40861e608e825711",
             "points": "13"
-        },
-        {
-            "name": "Iron Temple",
-            "email": "admin@irontemple.com",
-            "points": "4"
         },
         {
             "name": "Power Lift",
             "email": "admin@powerlift.com",
+            "password": "pbkdf2:sha256:150000$YEgAXbf8$09b68fdd4ab198aaf541a4b3a3b680449fff602e43bbfb1e602e970e9acf7b4c",
             "points": "5"
         },
         {
             "name": "She Lifts",
             "email": "kate@shelifts.co.uk",
+            "password": "pbkdf2:sha256:150000$g7r5qSMn$fecca97e2fcca7b093a4ca60789c4ebc0b6f4c0331aaaeee1ffa9f03a3404ad5",
             "points": "12"
+        },
+        {
+            "name": "Iron Temple",
+            "email": "admin@irontemple.com",
+            "password": "pbkdf2:sha256:150000$G0hKG0dK$434a98095c828d2735c63724fe9ae142a88d4aaba9489733c7fd614db655237a",
+            "points": "4"
         }
     ]
 }

--- a/clubs.json
+++ b/clubs.json
@@ -1,11 +1,6 @@
 {
     "clubs": [
         {
-            "name": "She Lifts",
-            "email": "kate@shelifts.co.uk",
-            "points": "12"
-        },
-        {
             "name": "Simply Lift",
             "email": "john@simplylift.co",
             "points": "13"
@@ -13,7 +8,17 @@
         {
             "name": "Iron Temple",
             "email": "admin@irontemple.com",
-            "points": "3"
+            "points": "4"
+        },
+        {
+            "name": "Power Lift",
+            "email": "admin@powerlift.com",
+            "points": "5"
+        },
+        {
+            "name": "She Lifts",
+            "email": "kate@shelifts.co.uk",
+            "points": "12"
         }
     ]
 }

--- a/clubs.json
+++ b/clubs.json
@@ -1,16 +1,19 @@
-{"clubs":[
-    {
-        "name":"Simply Lift",
-        "email":"john@simplylift.co",
-        "points":"13"
-    },
-    {
-        "name":"Iron Temple",
-        "email": "admin@irontemple.com",
-        "points":"4"
-    },
-    {   "name":"She Lifts",
-        "email": "kate@shelifts.co.uk",
-        "points":"15"
-    }
-]}
+{
+    "clubs": [
+        {
+            "name": "Simply Lift",
+            "email": "john@simplylift.co",
+            "points": "13"
+        },
+        {
+            "name": "She Lifts",
+            "email": "kate@shelifts.co.uk",
+            "points": "12"
+        },
+        {
+            "name": "Iron Temple",
+            "email": "admin@irontemple.com",
+            "points": "4"
+        }
+    ]
+}

--- a/clubs.json
+++ b/clubs.json
@@ -6,14 +6,14 @@
             "points": "12"
         },
         {
-            "name": "Iron Temple",
-            "email": "admin@irontemple.com",
-            "points": "4"
-        },
-        {
             "name": "Simply Lift",
             "email": "john@simplylift.co",
             "points": "13"
+        },
+        {
+            "name": "Iron Temple",
+            "email": "admin@irontemple.com",
+            "points": "4"
         }
     ]
 }

--- a/competitions.json
+++ b/competitions.json
@@ -6,14 +6,19 @@
             "number_of_places": "13"
         },
         {
-            "name": "Spring Festival",
-            "date": "2020-03-27 10:00:00",
-            "number_of_places": "25"
+            "name": "Winter Power",
+            "date": "2026-06-26 12:16:00",
+            "number_of_places": "4"
         },
         {
-            "name": "Winter Power",
-            "date": "2026-06-14 10:12:26",
-            "number_of_places": "4"
+            "name": "Summer Stronger",
+            "date": "2026-05-30 18:23:40",
+            "number_of_places": "0"
+        },
+        {
+            "name": "Spring Festival",
+            "date": "2026-07-27 10:00:00",
+            "number_of_places": "25"
         }
     ]
 }

--- a/competitions.json
+++ b/competitions.json
@@ -13,7 +13,7 @@
         {
             "name": "Winter Power",
             "date": "2026-06-14 10:12:26",
-            "number_of_places": "15"
+            "number_of_places": "4"
         }
     ]
 }

--- a/competitions.json
+++ b/competitions.json
@@ -3,12 +3,12 @@
         {
             "name": "Fall Classic",
             "date": "2020-10-22 13:30:00",
-            "numberOfPlaces": "13"
+            "number_of_places": "13"
         },
         {
             "name": "Spring Festival",
             "date": "2020-03-27 10:00:00",
-            "numberOfPlaces": "25"
+            "number_of_places": "25"
         }
     ]
 }

--- a/competitions.json
+++ b/competitions.json
@@ -1,14 +1,14 @@
 {
     "competitions": [
         {
-            "name": "Spring Festival",
-            "date": "2020-03-27 10:00:00",
-            "numberOfPlaces": "25"
-        },
-        {
             "name": "Fall Classic",
             "date": "2020-10-22 13:30:00",
             "numberOfPlaces": "13"
+        },
+        {
+            "name": "Spring Festival",
+            "date": "2020-03-27 10:00:00",
+            "numberOfPlaces": "25"
         }
     ]
 }

--- a/competitions.json
+++ b/competitions.json
@@ -9,6 +9,11 @@
             "name": "Spring Festival",
             "date": "2020-03-27 10:00:00",
             "number_of_places": "25"
+        },
+        {
+            "name": "Winter Power",
+            "date": "2026-06-14 10:12:26",
+            "number_of_places": "15"
         }
     ]
 }

--- a/server.py
+++ b/server.py
@@ -22,6 +22,10 @@ clubs = load_clubs()
 def update_club_booked_places(club, places, competition_name):
     clubs.remove(club)
 
+    club.setdefault("booked_places", {})
+    current = int(club["booked_places"].get(competition_name, 0))
+    club["booked_places"][competition_name] = str(current + places)
+
     club["points"] = str(int(club["points"]) - places)
 
     clubs.append(club)
@@ -66,7 +70,6 @@ def show_summary():
 @app.route('/book/<competition>/<club>')
 def book(competition, club):
     found_club = [c for c in clubs if c['name'] == club][0]
-    print(f"COMPETITIONS : {competitions}")
     found_competition = [c for c in competitions if c['name'] == competition][0]
     if found_club and found_competition:
         return render_template(template_name_or_list='booking.html',
@@ -85,6 +88,9 @@ def purchase_places():
     club = [c for c in clubs if c['name'] == request.form['club']][0]
     places_required = int(request.form['places'])
 
+    cumulative_places = places_required + int(club["booked_places"][competition["name"]]) \
+        if "booked_places" in club else places_required
+
     if places_required < 0:
         flash("Sorry, you should type a positive number.")
         return render_template(template_name_or_list='welcome.html',
@@ -92,7 +98,7 @@ def purchase_places():
                                competitions=competitions,
                                error="Negative number"), 403
 
-    elif places_required > 12:
+    elif cumulative_places > 12:
         flash("Sorry, you are not allow to purchase more than 12 places for this competition.")
         return render_template(template_name_or_list='welcome.html',
                                club=club,

--- a/server.py
+++ b/server.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import json
 from flask import Flask, render_template, request, redirect, flash, url_for
 
@@ -71,7 +72,20 @@ def show_summary():
 def book(competition, club):
     found_club = [c for c in clubs if c['name'] == club][0]
     found_competition = [c for c in competitions if c['name'] == competition][0]
-    if found_club and found_competition:
+
+    now = datetime.now()
+
+    competition_date = datetime.strptime(found_competition['date'], '%Y-%m-%d %H:%M:%S')
+
+    if now > competition_date:
+        flash("Sorry, this competition is outdated. Booking not possible.")
+        the_club = next((a_club for a_club in clubs if a_club['name'] == club), None)
+        return render_template(template_name_or_list='welcome.html',
+                               club=the_club,
+                               competitions=competitions,
+                               error = "Competition outdated"), 403
+
+    elif found_club and found_competition:
         return render_template(template_name_or_list='booking.html',
                                club=found_club,
                                competition=found_competition)
@@ -118,7 +132,7 @@ def purchase_places():
 
     update_competition_available_places(competition=competition, places=places_required)
 
-    flash('Great-booking complete!')
+    flash(f'Great-booking complete!')
     return render_template(template_name_or_list='welcome.html',
                            club=club,
                            competitions=competitions)

--- a/server.py
+++ b/server.py
@@ -83,7 +83,7 @@ def book(competition, club):
         return render_template(template_name_or_list='welcome.html',
                                club=the_club,
                                competitions=competitions,
-                               error = "Competition outdated"), 403
+                               error = "Outdated"), 403
 
     elif found_club and found_competition:
         return render_template(template_name_or_list='booking.html',
@@ -105,26 +105,31 @@ def purchase_places():
     cumulative_places = places_required + int(club["booked_places"][competition["name"]]) \
         if "booked_places" in club else places_required
 
+    error_message = ""
+    error_tag = ""
+
     if places_required < 0:
-        flash("Sorry, you should type a positive number.")
-        return render_template(template_name_or_list='welcome.html',
-                               club=club,
-                               competitions=competitions,
-                               error="Negative number"), 403
+        error_message = "Sorry, you should type a positive number."
+        error_tag = "Negative number"
 
     elif cumulative_places > 12:
-        flash("Sorry, you are not allow to purchase more than 12 places for this competition.")
-        return render_template(template_name_or_list='welcome.html',
-                               club=club,
-                               competitions=competitions,
-                               error="Places max reached"), 403
+        error_message = "Sorry, you are not allow to purchase more than 12 places for this competition."
+        error_tag = "Over 12 places"
+
+    elif places_required > int(competition['number_of_places']):
+        error_message = "Sorry, there are not enough places available for this competition."
+        error_tag = "Not enough places"
 
     elif places_required > int(club['points']):
-        flash("Sorry, you do not have enough points to purchase.")
+        error_message = "Sorry, you do not have enough points to purchase."
+        error_tag = "Not enough points"
+
+    if error_message and error_tag:
+        flash(error_message)
         return render_template(template_name_or_list='welcome.html',
                                club=club,
                                competitions=competitions,
-                               error="Points not enough"), 403
+                               error=error_tag), 403
 
     update_club_booked_places(club=club,
                               places=places_required,
@@ -132,7 +137,9 @@ def purchase_places():
 
     update_competition_available_places(competition=competition, places=places_required)
 
-    flash(f'Great-booking complete!')
+    flash(f"Great! Booking of {places_required} places for "
+          f"{competition['name']} competition complete!")
+
     return render_template(template_name_or_list='welcome.html',
                            club=club,
                            competitions=competitions)

--- a/server.py
+++ b/server.py
@@ -1,23 +1,23 @@
 import json
-from flask import Flask,render_template,request,redirect,flash,url_for
+from flask import Flask, render_template, request, redirect, flash, url_for
 
 
-def loadClubs():
+def load_clubs():
     with open('clubs.json') as c:
-         listOfClubs = json.load(c)['clubs']
-         return listOfClubs
+         list_of_clubs = json.load(c)['clubs']
+         return list_of_clubs
 
 
-def loadCompetitions():
+def load_competitions():
     with open('competitions.json') as comps:
-         listOfCompetitions = json.load(comps)['competitions']
-         return listOfCompetitions
+         list_of_competitions = json.load(comps)['competitions']
+         return list_of_competitions
 
 app = Flask(__name__)
 app.secret_key = 'something_special'
 
-competitions = loadCompetitions()
-clubs = loadClubs()
+competitions = load_competitions()
+clubs = load_clubs()
 
 def update_club_booked_places(club, places, competition_name):
     clubs.remove(club)
@@ -29,28 +29,28 @@ def update_club_booked_places(club, places, competition_name):
 
 def save_clubs():
     with open('clubs.json', 'w') as c:
-        listOfClubs = {"clubs": clubs}
-        json.dump(listOfClubs, c, indent=4)
+        list_of_clubs = {"clubs": clubs}
+        json.dump(list_of_clubs, c, indent=4)
 
 def update_competition_available_places(competition, places):
     competitions.remove(competition)
 
-    competition['numberOfPlaces'] = str(int(competition['numberOfPlaces']) - places)
+    competition['number_of_places'] = str(int(competition['number_of_places']) - places)
 
     competitions.append(competition)
     save_competitions()
 
 def save_competitions():
     with open('competitions.json', 'w') as comps:
-        listOfCompetitions = {"competitions": competitions}
-        json.dump(listOfCompetitions, comps, indent=4)
+        list_of_competitions = {"competitions": competitions}
+        json.dump(list_of_competitions, comps, indent=4)
 
 @app.route('/')
 def index():
     return render_template('index.html')
 
-@app.route('/showSummary',methods=['POST'])
-def showSummary():
+@app.route('/showSummary', methods=['POST'])
+def show_summary():
 
     club = next((club for club in clubs if club['email'] == request.form['email']), None)
 
@@ -64,13 +64,14 @@ def showSummary():
 
 
 @app.route('/book/<competition>/<club>')
-def book(competition,club):
-    foundClub = [c for c in clubs if c['name'] == club][0]
-    foundCompetition = [c for c in competitions if c['name'] == competition][0]
-    if foundClub and foundCompetition:
+def book(competition, club):
+    found_club = [c for c in clubs if c['name'] == club][0]
+    print(f"COMPETITIONS : {competitions}")
+    found_competition = [c for c in competitions if c['name'] == competition][0]
+    if found_club and found_competition:
         return render_template(template_name_or_list='booking.html',
-                               club=foundClub,
-                               competition=foundCompetition)
+                               club=found_club,
+                               competition=found_competition)
     else:
         flash("Something went wrong-please try again")
         return render_template(template_name_or_list='welcome.html',
@@ -79,27 +80,26 @@ def book(competition,club):
 
 
 @app.route('/purchasePlaces',methods=['POST'])
-def purchasePlaces():
+def purchase_places():
     competition = [c for c in competitions if c['name'] == request.form['competition']][0]
     club = [c for c in clubs if c['name'] == request.form['club']][0]
-    placesRequired = int(request.form['places'])
-    print(placesRequired)
+    places_required = int(request.form['places'])
 
-    if placesRequired < 0:
+    if places_required < 0:
         flash("Sorry, you should type a positive number.")
         return render_template(template_name_or_list='welcome.html',
                                club=club,
                                competitions=competitions,
                                error="Negative number"), 403
 
-    elif placesRequired > 12:
+    elif places_required > 12:
         flash("Sorry, you are not allow to purchase more than 12 places for this competition.")
         return render_template(template_name_or_list='welcome.html',
                                club=club,
                                competitions=competitions,
                                error="Places max reached"), 403
 
-    elif placesRequired > int(club['points']):
+    elif places_required > int(club['points']):
         flash("Sorry, you do not have enough points to purchase.")
         return render_template(template_name_or_list='welcome.html',
                                club=club,
@@ -107,10 +107,10 @@ def purchasePlaces():
                                error="Points not enough"), 403
 
     update_club_booked_places(club=club,
-                              places=placesRequired,
+                              places=places_required,
                               competition_name=competition["name"])
 
-    update_competition_available_places(competition=competition, places=placesRequired)
+    update_competition_available_places(competition=competition, places=places_required)
 
     flash('Great-booking complete!')
     return render_template(template_name_or_list='welcome.html',

--- a/server.py
+++ b/server.py
@@ -26,7 +26,13 @@ def index():
 
 @app.route('/showSummary',methods=['POST'])
 def showSummary():
-    club = [club for club in clubs if club['email'] == request.form['email']][0]
+
+    club = next((club for club in clubs if club['email'] == request.form['email']), None)
+
+    if club is None:
+        flash("Sorry, that email wasn't found.")
+        return render_template("index.html", error="Email not found"), 404
+
     return render_template('welcome.html',club=club,competitions=competitions)
 
 

--- a/server.py
+++ b/server.py
@@ -53,7 +53,11 @@ def purchasePlaces():
     club = [c for c in clubs if c['name'] == request.form['club']][0]
     placesRequired = int(request.form['places'])
 
-    if placesRequired > 12:
+    if placesRequired < 0:
+        flash("Sorry, you should type a positive number.")
+        return render_template('welcome.html', club=club, competitions=competitions, error="Negative number"), 403
+
+    elif placesRequired > 12:
         flash("Sorry, you are not allow to purchase more than 12 places.")
         return render_template('welcome.html', club=club, competitions=competitions, error="Places max reached"), 403
 

--- a/server.py
+++ b/server.py
@@ -77,20 +77,37 @@ def book(competition, club):
 
     competition_date = datetime.strptime(found_competition['date'], '%Y-%m-%d %H:%M:%S')
 
+    error_message = ""
+    error_tag = ""
+
+    the_competition = next((a_competition for a_competition in competitions
+                            if a_competition['name'] == competition), None)
+    competition_places = int(the_competition['number_of_places'])
+
     if now > competition_date:
-        flash("Sorry, this competition is outdated. Booking not possible.")
+        error_message = "Sorry, this competition is outdated. Booking not possible."
+        error_tag = "Outdated"
+
+    elif competition_places == 0:
+        error_message = "Sorry, this competition is sold out. Booking not possible."
+        error_tag = "Sold out"
+
+    if error_message and error_tag:
+        flash(error_message)
+
         the_club = next((a_club for a_club in clubs if a_club['name'] == club), None)
+
         return render_template(template_name_or_list='welcome.html',
                                club=the_club,
                                competitions=competitions,
-                               error = "Outdated"), 403
+                               error=error_tag), 403
 
-    elif found_club and found_competition:
+    if found_club and found_competition:
         return render_template(template_name_or_list='booking.html',
                                club=found_club,
                                competition=found_competition)
     else:
-        flash("Something went wrong-please try again")
+        flash("Sorry, something went wrong. Please try again.")
         return render_template(template_name_or_list='welcome.html',
                                club=club,
                                competitions=competitions)

--- a/server.py
+++ b/server.py
@@ -52,6 +52,11 @@ def purchasePlaces():
     competition = [c for c in competitions if c['name'] == request.form['competition']][0]
     club = [c for c in clubs if c['name'] == request.form['club']][0]
     placesRequired = int(request.form['places'])
+
+    if placesRequired > int(club['points']):
+        flash("Sorry, you do not have enough points to purchase.")
+        return render_template('welcome.html', club=club, competitions=competitions, error="Points not enough"), 403
+
     competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-placesRequired
     flash('Great-booking complete!')
     return render_template('welcome.html', club=club, competitions=competitions)

--- a/server.py
+++ b/server.py
@@ -53,7 +53,11 @@ def purchasePlaces():
     club = [c for c in clubs if c['name'] == request.form['club']][0]
     placesRequired = int(request.form['places'])
 
-    if placesRequired > int(club['points']):
+    if placesRequired > 12:
+        flash("Sorry, you are not allow to purchase more than 12 places.")
+        return render_template('welcome.html', club=club, competitions=competitions, error="Places max reached"), 403
+
+    elif placesRequired > int(club['points']):
         flash("Sorry, you do not have enough points to purchase.")
         return render_template('welcome.html', club=club, competitions=competitions, error="Points not enough"), 403
 

--- a/server.py
+++ b/server.py
@@ -1,6 +1,8 @@
-from datetime import datetime
 import json
+
+from datetime import datetime
 from flask import Flask, render_template, request, redirect, flash, url_for
+from werkzeug.security import generate_password_hash, check_password_hash
 
 
 def load_clubs():
@@ -19,6 +21,8 @@ app.secret_key = 'something_special'
 
 competitions = load_competitions()
 clubs = load_clubs()
+
+CLUB_POINTS = 15
 
 def update_club_booked_places(club, places, competition_name):
     clubs.remove(club)
@@ -50,23 +54,119 @@ def save_competitions():
         list_of_competitions = {"competitions": competitions}
         json.dump(list_of_competitions, comps, indent=4)
 
+def add_club(name, email, password, points):
+    clubs.append({"name": name, "email": email, "password": password, "points": points})
+    save_clubs()
+
+def update_club_password(club, password):
+    club["password"] = password
+    save_clubs()
+    return club
+
 @app.route('/')
 def index():
     return render_template('index.html')
 
+@app.route('/signUp')
+def sign_up():
+    return render_template('sign_up.html')
+
+@app.route('/profile/<club>', methods=['GET'])
+def profile(club):
+    the_club = next((c for c in clubs if c['name'] == club), None)
+
+    if the_club is None:
+        flash("Sorry, that club was not found.")
+        return render_template(template_name_or_list="index.html", error="Club not found"), 404
+
+    return render_template(template_name_or_list='profile.html', club=the_club)
+
+@app.route('/profile', methods=['POST'])
+def profile_post():
+    club_name = request.form['name']
+    club_email = request.form['email']
+    club_password = request.form['password']
+    club_password_confirmation = request.form['confirm_password']
+
+    club_exists = next((c for c in clubs if c['email'] == club_email or c['name'] == club_name), None)
+    if club_exists is None:
+        if club_password != club_password_confirmation:
+            flash('Sorry, passwords do not match')
+            return redirect(url_for('sign_up'))
+
+        hashed_password = generate_password_hash(club_password)
+        add_club(club_name, club_email, hashed_password, str(CLUB_POINTS))
+
+        the_club = next((c for c in clubs if c['email'] == club_email), None)
+
+        if the_club is None:
+            flash("Sorry, something went wrong. Please try again.")
+            return render_template(template_name_or_list='sign_up.html')
+
+        flash("Great! You have successfully signed up.")
+        return render_template(template_name_or_list='profile.html', club=the_club)
+
+    else:
+        flash("Sorry, the club already exists.")
+        return render_template(template_name_or_list='sign_up.html')
+
+@app.route('/changePassword/<club>', methods=['GET', 'POST'])
+def change_password(club):
+    if request.method == 'GET':
+        the_club = next((c for c in clubs if c['name'] == club), None)
+
+        if the_club is None:
+            flash("Sorry, that club was not found.")
+            return render_template(template_name_or_list="index.html", error="Email not found"), 404
+
+        return render_template(template_name_or_list='change_password.html', club=the_club)
+    else:
+        club_password = request.form['password']
+        club_password_confirmation = request.form['confirm_password']
+
+        if club_password != club_password_confirmation:
+            flash('Sorry, passwords do not match')
+            return redirect(url_for('change_password'))
+
+        the_club = next((c for c in clubs if c['name'] == club), None)
+        hashed_password = generate_password_hash(club_password)
+
+        if check_password_hash(the_club['password'], club_password):
+            flash('Sorry, you have to type a new different password.')
+            return render_template(template_name_or_list='change_password.html', club=the_club)
+
+        the_club = update_club_password(the_club, hashed_password)
+
+        if the_club:
+            flash("Great! You have successfully changed your password.")
+            return render_template(template_name_or_list='profile.html', club=the_club)
+
+        flash("Sorry, something went wrong. Please try again.")
+        return render_template(template_name_or_list='index.html')
+
+
+@app.route('/showSummary/<club>', methods=['GET'])
+def show_summary(club):
+    the_club = next((c for c in clubs if c['name'] == club), None)
+    return render_template(template_name_or_list='welcome.html',
+                           club=the_club,
+                           competitions=competitions)
+
 @app.route('/showSummary', methods=['POST'])
-def show_summary():
+def show_summary_post():
+    the_club = next((c for c in clubs if c['email'] == request.form['email']), None)
 
-    club = next((club for club in clubs if club['email'] == request.form['email']), None)
-
-    if club is None:
+    if the_club is None:
         flash("Sorry, that email was not found.")
         return render_template(template_name_or_list="index.html", error="Email not found"), 404
 
-    return render_template(template_name_or_list='welcome.html',
-                           club=club,
-                           competitions=competitions)
+    if not check_password_hash(the_club['password'], request.form['password']):
+        flash("Sorry, the password is incorrect.")
+        return render_template(template_name_or_list="index.html",)
 
+    return render_template(template_name_or_list='welcome.html',
+                           club=the_club,
+                           competitions=competitions)
 
 @app.route('/book/<competition>/<club>')
 def book(competition, club):

--- a/server.py
+++ b/server.py
@@ -13,12 +13,37 @@ def loadCompetitions():
          listOfCompetitions = json.load(comps)['competitions']
          return listOfCompetitions
 
-
 app = Flask(__name__)
 app.secret_key = 'something_special'
 
 competitions = loadCompetitions()
 clubs = loadClubs()
+
+def update_club_booked_places(club, places, competition_name):
+    clubs.remove(club)
+
+    club["points"] = str(int(club["points"]) - places)
+
+    clubs.append(club)
+    save_clubs()
+
+def save_clubs():
+    with open('clubs.json', 'w') as c:
+        listOfClubs = {"clubs": clubs}
+        json.dump(listOfClubs, c, indent=4)
+
+def update_competition_available_places(competition, places):
+    competitions.remove(competition)
+
+    competition['numberOfPlaces'] = str(int(competition['numberOfPlaces']) - places)
+
+    competitions.append(competition)
+    save_competitions()
+
+def save_competitions():
+    with open('competitions.json', 'w') as comps:
+        listOfCompetitions = {"competitions": competitions}
+        json.dump(listOfCompetitions, comps, indent=4)
 
 @app.route('/')
 def index():
@@ -31,9 +56,11 @@ def showSummary():
 
     if club is None:
         flash("Sorry, that email was not found.")
-        return render_template("index.html", error="Email not found"), 404
+        return render_template(template_name_or_list="index.html", error="Email not found"), 404
 
-    return render_template('welcome.html',club=club,competitions=competitions)
+    return render_template(template_name_or_list='welcome.html',
+                           club=club,
+                           competitions=competitions)
 
 
 @app.route('/book/<competition>/<club>')
@@ -41,10 +68,14 @@ def book(competition,club):
     foundClub = [c for c in clubs if c['name'] == club][0]
     foundCompetition = [c for c in competitions if c['name'] == competition][0]
     if foundClub and foundCompetition:
-        return render_template('booking.html',club=foundClub,competition=foundCompetition)
+        return render_template(template_name_or_list='booking.html',
+                               club=foundClub,
+                               competition=foundCompetition)
     else:
         flash("Something went wrong-please try again")
-        return render_template('welcome.html', club=club, competitions=competitions)
+        return render_template(template_name_or_list='welcome.html',
+                               club=club,
+                               competitions=competitions)
 
 
 @app.route('/purchasePlaces',methods=['POST'])
@@ -52,22 +83,39 @@ def purchasePlaces():
     competition = [c for c in competitions if c['name'] == request.form['competition']][0]
     club = [c for c in clubs if c['name'] == request.form['club']][0]
     placesRequired = int(request.form['places'])
+    print(placesRequired)
 
     if placesRequired < 0:
         flash("Sorry, you should type a positive number.")
-        return render_template('welcome.html', club=club, competitions=competitions, error="Negative number"), 403
+        return render_template(template_name_or_list='welcome.html',
+                               club=club,
+                               competitions=competitions,
+                               error="Negative number"), 403
 
     elif placesRequired > 12:
-        flash("Sorry, you are not allow to purchase more than 12 places.")
-        return render_template('welcome.html', club=club, competitions=competitions, error="Places max reached"), 403
+        flash("Sorry, you are not allow to purchase more than 12 places for this competition.")
+        return render_template(template_name_or_list='welcome.html',
+                               club=club,
+                               competitions=competitions,
+                               error="Places max reached"), 403
 
     elif placesRequired > int(club['points']):
         flash("Sorry, you do not have enough points to purchase.")
-        return render_template('welcome.html', club=club, competitions=competitions, error="Points not enough"), 403
+        return render_template(template_name_or_list='welcome.html',
+                               club=club,
+                               competitions=competitions,
+                               error="Points not enough"), 403
 
-    competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-placesRequired
+    update_club_booked_places(club=club,
+                              places=placesRequired,
+                              competition_name=competition["name"])
+
+    update_competition_available_places(competition=competition, places=placesRequired)
+
     flash('Great-booking complete!')
-    return render_template('welcome.html', club=club, competitions=competitions)
+    return render_template(template_name_or_list='welcome.html',
+                           club=club,
+                           competitions=competitions)
 
 
 # TODO: Add route for points display

--- a/server.py
+++ b/server.py
@@ -30,7 +30,7 @@ def showSummary():
     club = next((club for club in clubs if club['email'] == request.form['email']), None)
 
     if club is None:
-        flash("Sorry, that email wasn't found.")
+        flash("Sorry, that email was not found.")
         return render_template("index.html", error="Email not found"), 404
 
     return render_template('welcome.html',club=club,competitions=competitions)

--- a/templates/booking.html
+++ b/templates/booking.html
@@ -6,8 +6,8 @@
 </head>
 <body>
     <h2>{{competition['name']}}</h2>
-    Places available: {{competition['numberOfPlaces']}}
-    <form action="/purchasePlaces" method="post">
+    Places available: {{competition['number_of_places']}}
+    <form action="/purchase_places" method="post">
         <input type="hidden" name="club" value="{{club['name']}}">
         <input type="hidden" name="competition" value="{{competition['name']}}">
         <label for="places">How many places?</label><input type="number" name="places" id=""/>

--- a/templates/booking.html
+++ b/templates/booking.html
@@ -7,7 +7,7 @@
 <body>
     <h2>{{competition['name']}}</h2>
     Places available: {{competition['number_of_places']}}
-    <form action="/purchase_places" method="post">
+    <form action="/purchasePlaces" method="post">
         <input type="hidden" name="club" value="{{club['name']}}">
         <input type="hidden" name="competition" value="{{competition['name']}}">
         <label for="places">How many places?</label><input type="number" name="places" id=""/>

--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -5,7 +5,7 @@
     <title>GUDLFT Registration</title>
 </head>
 <body>
-    <h1>Welcome to the GUDLFT Registration Portal!</h1>
+    <h1>Welcome to the GUDLFT - Change password page !</h1>
 
     {% with messages = get_flashed_messages()%}
         {% if messages %}
@@ -17,15 +17,17 @@
         {% endif%}
     {%endwith%}
 
-    Please enter your secretary email and your password to continue or <a href="{{url_for('sign_up')}}">sign up</a>
-    <br>
-    <br>
-    <form action="showSummary" method="post">
-        <label for="email">Email:</label>
-        <input type="email" name="email" id=""/>
+    Please enter your new password:<br><br>
 
+    Name : {{club['name']}}<br>
+    Email : {{club['email']}}
+    <br><br>
+    <form action="{{ url_for('change_password', club=club['name']) }}" method="post">
         <label for="password">Password:</label>
         <input type="password" name="password" id=""/>
+
+        <label for="confirm_password">Confirm Password:</label>
+        <input type="password" name="confirm_password" id=""/>
 
         <button type="submit">Enter</button>
     </form>

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,7 +18,7 @@
     {%endwith%}
 
     Please enter your secretary email to continue:
-    <form action="showSummary" method="post">
+    <form action="show_summary" method="post">
         <label for="email">Email:</label>
         <input type="email" name="email" id=""/>
         <button type="submit">Enter</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,7 +18,7 @@
     {%endwith%}
 
     Please enter your secretary email to continue:
-    <form action="show_summary" method="post">
+    <form action="showSummary" method="post">
         <label for="email">Email:</label>
         <input type="email" name="email" id=""/>
         <button type="submit">Enter</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,6 +6,17 @@
 </head>
 <body>
     <h1>Welcome to the GUDLFT Registration Portal!</h1>
+
+    {% with messages = get_flashed_messages()%}
+        {% if messages %}
+            <ul>
+           {% for message in messages %}
+                <li>{{message}}</li>
+            {% endfor %}
+           </ul>
+        {% endif%}
+    {%endwith%}
+
     Please enter your secretary email to continue:
     <form action="showSummary" method="post">
         <label for="email">Email:</label>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,0 +1,32 @@
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Summary | GUDLFT Profile</title>
+</head>
+<body>
+        <h2>Welcome, {{club['email']}} </h2><a href="{{url_for('logout')}}">Logout</a>
+
+    {% with messages = get_flashed_messages()%}
+    {% if messages %}
+        <ul>
+       {% for message in messages %}
+            <li>{{message}}</li>
+        {% endfor %}
+       </ul>
+    {% endif%}
+    <h3>Profile:</h3>
+    <ul>
+        <li>Name : {{club['name']}}</li>
+        <li>Email : {{club['email']}}</li>
+        <li>password : {{club['password']}} - <a href="{{url_for('change_password', club=club['name'])}}">Change password</a></li>
+        <br>
+        <li>Points available: {{club['points']}}</li>
+    </ul>
+    <br>
+    <a href="{{url_for('show_summary', club=club['name'])}}">Go to home page</a>
+
+    {%endwith%}
+
+</body>
+</html>

--- a/templates/sign_up.html
+++ b/templates/sign_up.html
@@ -2,10 +2,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>GUDLFT Registration</title>
+    <title>GUDLFT Sign up</title>
 </head>
 <body>
-    <h1>Welcome to the GUDLFT Registration Portal!</h1>
+    <h1>Welcome to the GUDLFT sign up page!</h1>
 
     {% with messages = get_flashed_messages()%}
         {% if messages %}
@@ -17,15 +17,19 @@
         {% endif%}
     {%endwith%}
 
-    Please enter your secretary email and your password to continue or <a href="{{url_for('sign_up')}}">sign up</a>
-    <br>
-    <br>
-    <form action="showSummary" method="post">
+    Please enter your secretary email and your password:
+    <form action="profile" method="post">
+        <label for="name">Club name:</label>
+        <input type="text" name="name" id=""/>
+
         <label for="email">Email:</label>
         <input type="email" name="email" id=""/>
 
         <label for="password">Password:</label>
         <input type="password" name="password" id=""/>
+
+        <label for="confirm_password">Confirm Password:</label>
+        <input type="password" name="confirm_password" id=""/>
 
         <button type="submit">Enter</button>
     </form>

--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -22,8 +22,8 @@
         <li>
             {{comp['name']}}<br />
             Date: {{comp['date']}}</br>
-            Number of Places: {{comp['numberOfPlaces']}}
-            {%if comp['numberOfPlaces']|int >0%}
+            Number of Places: {{comp['number_of_places']}}
+            {%if comp['number_of_places']|int >0%}
             <a href="{{ url_for('book',competition=comp['name'],club=club['name']) }}">Book Places</a>
             {%endif%}
         </li>

--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -5,7 +5,7 @@
     <title>Summary | GUDLFT Registration</title>
 </head>
 <body>
-        <h2>Welcome, {{club['email']}} </h2><a href="{{url_for('logout')}}">Logout</a>
+        <h2>Welcome, {{club['email']}} </h2><a href="{{url_for('logout')}}">Logout</a><br><br>
 
     {% with messages = get_flashed_messages()%}
     {% if messages %}
@@ -15,6 +15,9 @@
         {% endfor %}
        </ul>
     {% endif%}
+
+    <a href="{{ url_for('profile', club=club['name']) }}">Go to profile</a>
+    <br>
     Points available: {{club['points']}}
     <h3>Competitions:</h3>
     <ul>

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 from random import randint
-
+from werkzeug.security import generate_password_hash
 from server import app
 
 @pytest.fixture
@@ -16,15 +16,18 @@ def get_clubs():
     {
         "name":"Simply Lift",
         "email":"john@simplylift.co",
+        "password": generate_password_hash("tp1_Tmn28"),
         "points":"13"
     },
     {
         "name":"Iron Temple",
         "email": "admin@irontemple.com",
+        "password": generate_password_hash("tp2_Tmn29"),
         "points":"4"
     },
     {   "name":"She Lifts",
         "email": "kate@shelifts.co.uk",
+        "password": generate_password_hash("tp3_Tmn30"),
         "points":"12",
         "booked_places": {
                             "Spring Festival": "7"
@@ -33,6 +36,7 @@ def get_clubs():
     {
         "name": "Power Lift",
         "email": "admin@powerlift.com",
+        "password": generate_password_hash("tp4_Tmn40"),
         "points": "5"
     }
     ]
@@ -65,18 +69,18 @@ def get_competitions():
     return the_competitions
 
 @pytest.fixture
-def get_existing_mail():
-    data = {"email": "kate@shelifts.co.uk"}
+def get_credentials():
+    data = {"email": "kate@shelifts.co.uk", "password": "tp3_Tmn30"}
     return data
 
 @pytest.fixture
-def get_existing_mail_2():
-    data = {"email": "admin@irontemple.com"}
+def get_credentials_2():
+    data = {"email": "admin@irontemple.com", "password": "tp2_Tmn29"}
     return data
 
 @pytest.fixture
-def get_unexisting_mail():
-    data = {"email": "nicolas.marie@unexisting.com"}
+def get_unexisting_credentials():
+    data = {"email": "nicolas.marie@unexisting.com", "password": "er45_shet"}
     return data
 
 @pytest.fixture

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -29,6 +29,11 @@ def get_clubs():
         "booked_places": {
                             "Spring Festival": "7"
                         }
+    },
+    {
+        "name": "Power Lift",
+        "email": "admin@powerlift.com",
+        "points": "5"
     }
     ]
     return the_clubs
@@ -45,6 +50,11 @@ def get_competitions():
             "name": "Spring Festival",
             "date": "2026-07-27 10:00:00",
             "number_of_places": "25"
+        },
+        {
+            "name": "Winter Power",
+            "date": "2026-06-26 12:16:00",
+            "number_of_places": "4"
         }
     ]
     return the_competitions
@@ -77,6 +87,11 @@ def get_existing_competition_and_club_2():
 @pytest.fixture
 def get_existing_competition_and_club_3():
     data = {"competition": "Fall Classic", "club": "Iron Temple"}
+    return data
+
+@pytest.fixture
+def get_existing_competition_and_club_4():
+    data = {"competition": "Winter Power", "club": "Power Lift"}
     return data
 
 @pytest.fixture
@@ -121,6 +136,15 @@ def purchasing_with_negative_places():
     competition = "Spring Festival"
     club_name = "She Lifts"
     places_to_book = -2
+    data = {"competition": competition, "club": club_name, "places": str(places_to_book)}
+
+    return data
+
+@pytest.fixture
+def purchasing_places_more_than_available():
+    competition = "Winter Power"
+    club_name = "Power Lift"
+    places_to_book = 5
     data = {"competition": competition, "club": club_name, "places": str(places_to_book)}
 
     return data

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -10,26 +10,68 @@ def client():
     with my_app.test_client() as client:
         yield client
 
+@pytest.fixture
+def get_clubs():
+    the_clubs = [
+    {
+        "name":"Simply Lift",
+        "email":"john@simplylift.co",
+        "points":"13"
+    },
+    {
+        "name":"Iron Temple",
+        "email": "admin@irontemple.com",
+        "points":"4"
+    },
+    {   "name":"She Lifts",
+        "email": "kate@shelifts.co.uk",
+        "points":"12"
+    }
+    ]
+    return the_clubs
+
+@pytest.fixture
+def get_competitions():
+    the_competitions = [
+        {
+            "name": "Fall Classic",
+            "date": "2020-10-22 13:30:00",
+            "numberOfPlaces": "13"
+        },
+        {
+            "name": "Spring Festival",
+            "date": "2020-03-27 10:00:00",
+            "numberOfPlaces": "25"
+        }
+    ]
+    return the_competitions
+
+@pytest.fixture
 def get_existing_mail():
     data = {"email": "kate@shelifts.co.uk"}
     return data
 
+@pytest.fixture
 def get_existing_mail_2():
     data = {"email": "admin@irontemple.com"}
     return data
 
+@pytest.fixture
 def get_unexisting_mail():
     data = {"email": "nicolas.marie@unexisting.com"}
     return data
 
+@pytest.fixture
 def get_existing_competition_and_club():
     data = {"competition": "Spring Festival", "club": "She Lifts"}
     return data
 
+@pytest.fixture
 def get_existing_competition_and_club_2():
     data = {"competition": "Spring Festival", "club": "Iron Temple"}
     return data
 
+@pytest.fixture
 def get_consistent_purchasing_data():
     competition = "Spring Festival"
     club_name = "She Lifts"
@@ -38,6 +80,7 @@ def get_consistent_purchasing_data():
 
     return data
 
+@pytest.fixture
 def get_inconsistent_purchasing_data():
     competition = "Spring Festival"
     club_name = "Iron Temple"
@@ -47,7 +90,8 @@ def get_inconsistent_purchasing_data():
 
     return data
 
-def get_inconsistent_purchasing_data_over_12_places():
+@pytest.fixture
+def purchasing_data_over_12_places():
     competition = "Spring Festival"
     club_name = "She Lifts"
     places_to_book = 13
@@ -55,7 +99,8 @@ def get_inconsistent_purchasing_data_over_12_places():
 
     return data
 
-def get_inconsistent_purchasing_data_with_negative_places():
+@pytest.fixture
+def purchasing_data_with_negative_places():
     competition = "Spring Festival"
     club_name = "She Lifts"
     places_to_book = -2

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -25,7 +25,10 @@ def get_clubs():
     },
     {   "name":"She Lifts",
         "email": "kate@shelifts.co.uk",
-        "points":"12"
+        "points":"12",
+        "booked_places": {
+                            "Spring Festival": "7"
+                        }
     }
     ]
     return the_clubs
@@ -75,7 +78,7 @@ def get_existing_competition_and_club_2():
 def get_consistent_purchasing_data():
     competition = "Spring Festival"
     club_name = "She Lifts"
-    places_to_book = randint(1, 12)
+    places_to_book = randint(1, 5)
     data = {"competition": competition, "club": club_name, "places": str(places_to_book)}
 
     return data
@@ -91,7 +94,7 @@ def get_inconsistent_purchasing_data():
     return data
 
 @pytest.fixture
-def purchasing_data_over_12_places():
+def purchasing_over_12_places():
     competition = "Spring Festival"
     club_name = "She Lifts"
     places_to_book = 13
@@ -100,7 +103,16 @@ def purchasing_data_over_12_places():
     return data
 
 @pytest.fixture
-def purchasing_data_with_negative_places():
+def purchasing_13_cumulative_places():
+    competition = "Spring Festival"
+    club_name = "She Lifts"
+    places_to_book = 6
+    data = {"competition": competition, "club": club_name, "places": str(places_to_book)}
+
+    return data
+
+@pytest.fixture
+def purchasing_with_negative_places():
     competition = "Spring Festival"
     club_name = "She Lifts"
     places_to_book = -2

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 from random import randint
 
-from server import app, clubs
+from server import app
 
 @pytest.fixture
 def client():
@@ -36,12 +36,12 @@ def get_competitions():
         {
             "name": "Fall Classic",
             "date": "2020-10-22 13:30:00",
-            "numberOfPlaces": "13"
+            "number_of_places": "13"
         },
         {
             "name": "Spring Festival",
             "date": "2020-03-27 10:00:00",
-            "numberOfPlaces": "25"
+            "number_of_places": "25"
         }
     ]
     return the_competitions

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -43,7 +43,7 @@ def get_competitions():
         },
         {
             "name": "Spring Festival",
-            "date": "2020-03-27 10:00:00",
+            "date": "2026-07-27 10:00:00",
             "number_of_places": "25"
         }
     ]
@@ -72,6 +72,11 @@ def get_existing_competition_and_club():
 @pytest.fixture
 def get_existing_competition_and_club_2():
     data = {"competition": "Spring Festival", "club": "Iron Temple"}
+    return data
+
+@pytest.fixture
+def get_existing_competition_and_club_3():
+    data = {"competition": "Fall Classic", "club": "Iron Temple"}
     return data
 
 @pytest.fixture

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -55,6 +55,11 @@ def get_competitions():
             "name": "Winter Power",
             "date": "2026-06-26 12:16:00",
             "number_of_places": "4"
+        },
+        {
+            "name": "Summer Stronger",
+            "date": "2026-05-30 18:23:40",
+            "number_of_places": "0"
         }
     ]
     return the_competitions
@@ -91,7 +96,7 @@ def get_existing_competition_and_club_3():
 
 @pytest.fixture
 def get_existing_competition_and_club_4():
-    data = {"competition": "Winter Power", "club": "Power Lift"}
+    data = {"competition": "Summer Stronger", "club": "Power Lift"}
     return data
 
 @pytest.fixture

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -54,3 +54,11 @@ def get_inconsistent_purchasing_data_over_12_places():
     data = {"competition": competition, "club": club_name, "places": str(places_to_book)}
 
     return data
+
+def get_inconsistent_purchasing_data_with_negative_places():
+    competition = "Spring Festival"
+    club_name = "She Lifts"
+    places_to_book = -2
+    data = {"competition": competition, "club": club_name, "places": str(places_to_book)}
+
+    return data

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -1,0 +1,56 @@
+import pytest
+
+from random import randint
+
+from server import app, clubs
+
+@pytest.fixture
+def client():
+    my_app = app
+    with my_app.test_client() as client:
+        yield client
+
+def get_existing_mail():
+    data = {"email": "kate@shelifts.co.uk"}
+    return data
+
+def get_existing_mail_2():
+    data = {"email": "admin@irontemple.com"}
+    return data
+
+def get_unexisting_mail():
+    data = {"email": "nicolas.marie@unexisting.com"}
+    return data
+
+def get_existing_competition_and_club():
+    data = {"competition": "Spring Festival", "club": "She Lifts"}
+    return data
+
+def get_existing_competition_and_club_2():
+    data = {"competition": "Spring Festival", "club": "Iron Temple"}
+    return data
+
+def get_consistent_purchasing_data():
+    competition = "Spring Festival"
+    club_name = "She Lifts"
+    places_to_book = randint(1, 12)
+    data = {"competition": competition, "club": club_name, "places": str(places_to_book)}
+
+    return data
+
+def get_inconsistent_purchasing_data():
+    competition = "Spring Festival"
+    club_name = "Iron Temple"
+    club_points = 4
+    places_to_book = randint(club_points+1, 12)
+    data = {"competition": competition, "club": club_name, "places": str(places_to_book)}
+
+    return data
+
+def get_inconsistent_purchasing_data_over_12_places():
+    competition = "Spring Festival"
+    club_name = "She Lifts"
+    places_to_book = 13
+    data = {"competition": competition, "club": club_name, "places": str(places_to_book)}
+
+    return data

--- a/unit_tests/test_app.py
+++ b/unit_tests/test_app.py
@@ -1,8 +1,11 @@
-from Scripts.bottle import response
 from bs4 import BeautifulSoup
 from flask import url_for
 
 import server
+
+def patch_clubs_and_competitions(mocker, get_clubs, get_competitions):
+    mocker.patch('server.clubs', get_clubs)
+    mocker.patch('server.competitions', get_competitions)
 
 def test_index_status_code_ok(client):
     client_response = client.get('/')
@@ -67,8 +70,7 @@ def test_booking_status_code_ok(mocker,
                                 get_clubs,
                                 get_competitions):
 
-    mocker.patch('server.clubs', get_clubs)
-    mocker.patch('server.competitions', get_competitions)
+    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
 
     client.post('/showSummary', data=get_existing_mail)
 
@@ -85,8 +87,7 @@ def test_booking_return_festival_page_booking(mocker,
                                               get_clubs,
                                               get_competitions):
 
-    mocker.patch('server.clubs', get_clubs)
-    mocker.patch('server.competitions', get_competitions)
+    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
 
     client.post('/showSummary', data=get_existing_mail)
 
@@ -106,8 +107,7 @@ def test_good_purchasing_places_status_code_ok(mocker,
                                                get_clubs,
                                                get_competitions):
 
-    mocker.patch('server.clubs', get_clubs)
-    mocker.patch('server.competitions', get_competitions)
+    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
 
     client.post('/showSummary', data=get_existing_mail)
     client.get(url_for(endpoint='book',
@@ -125,8 +125,7 @@ def test_good_purchasing_places_returns_summary_page(mocker, client, get_existin
                                                      get_consistent_purchasing_data,
                                                      get_competitions):
 
-    mocker.patch('server.clubs', get_clubs)
-    mocker.patch('server.competitions', get_competitions)
+    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
 
     client.post('/showSummary', data=get_existing_mail)
 
@@ -176,8 +175,7 @@ def test_purchasing_places_not_enough_points_status_code_error(mocker,
                                                                get_clubs,
                                                                get_competitions):
 
-    mocker.patch('server.clubs', get_clubs)
-    mocker.patch('server.competitions', get_competitions)
+    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
 
     client.post('/showSummary', data=get_existing_mail_2)
     client.get(url_for(endpoint='book',
@@ -195,8 +193,8 @@ def test_purchasing_places_not_enough_points_returns_sorry(mocker,
                                                            get_inconsistent_purchasing_data,
                                                            get_clubs,
                                                            get_competitions):
-    mocker.patch('server.clubs', get_clubs)
-    mocker.patch('server.competitions', get_competitions)
+
+    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
 
     client.post('/showSummary', data=get_existing_mail_2)
     client.get(url_for(endpoint='book',
@@ -219,8 +217,8 @@ def test_purchasing_places_over_12_places_status_code_error(mocker,
                                                             purchasing_over_12_places,
                                                             get_clubs,
                                                             get_competitions):
-    mocker.patch('server.clubs', get_clubs)
-    mocker.patch('server.competitions', get_competitions)
+
+    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
 
     client.post('/showSummary', data=get_existing_mail)
     client.get(url_for(endpoint='book',
@@ -238,8 +236,8 @@ def test_purchasing_places_over_12_places_returns_sorry(mocker,
                                                         purchasing_over_12_places,
                                                         get_clubs,
                                                         get_competitions):
-    mocker.patch('server.clubs', get_clubs)
-    mocker.patch('server.competitions', get_competitions)
+
+    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
 
     client.post('/showSummary', data=get_existing_mail)
 
@@ -264,8 +262,8 @@ def test_purchasing_places_over_12_cumulative_places_returns_sorry(mocker,
                                                                    purchasing_13_cumulative_places,
                                                                    get_clubs,
                                                                    get_competitions):
-    mocker.patch('server.clubs', get_clubs)
-    mocker.patch('server.competitions', get_competitions)
+
+    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
 
     client.post('/showSummary', data=get_existing_mail)
 
@@ -291,8 +289,7 @@ def test_purchasing_places_negative_number_status_code_error(mocker,
                                                              purchasing_with_negative_places,
                                                              get_competitions):
 
-    mocker.patch('server.clubs', get_clubs)
-    mocker.patch('server.competitions', get_competitions)
+    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
 
     client.post('/showSummary', data=get_existing_mail)
 
@@ -313,8 +310,8 @@ def test_purchasing_places_negative_number_returns_sorry(mocker,
                                                          purchasing_with_negative_places,
                                                          get_clubs,
                                                          get_competitions):
-    mocker.patch('server.clubs', get_clubs)
-    mocker.patch('server.competitions', get_competitions)
+
+    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
 
     client.post('/showSummary', data=get_existing_mail)
 
@@ -339,8 +336,7 @@ def test_purchasing_places_past_competitions_status_code_error(mocker,
                                                                get_clubs,
                                                                get_competitions):
 
-    mocker.patch('server.clubs', get_clubs)
-    mocker.patch('server.competitions', get_competitions)
+    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
 
     client.post('/showSummary', data=get_existing_mail)
 
@@ -356,8 +352,8 @@ def test_purchasing_places_past_competitions_returns_sorry(mocker,
                                                            get_existing_competition_and_club_3,
                                                            get_clubs,
                                                            get_competitions):
-    mocker.patch('server.clubs', get_clubs)
-    mocker.patch('server.competitions', get_competitions)
+
+    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
 
     client.post('/showSummary', data=get_existing_mail)
 

--- a/unit_tests/test_app.py
+++ b/unit_tests/test_app.py
@@ -26,17 +26,19 @@ class TestApp:
         data = client_response.data.decode('utf-8')
 
         assert "Welcome to the GUDLFT Registration Portal!" in data
-        assert "Please enter your secretary email to continue:" in data
+        assert ('Please enter your secretary email and your password to continue '
+                'or <a href="/signUp">sign up</a>') in data
         assert "Email:" in data
+        assert "Password:" in data
 
     @staticmethod
-    def test_index_mail_authentication_ok(get_existing_mail, mocker, client):
-        client_response = client.post('/showSummary', data=get_existing_mail)
+    def test_index_mail_authentication_ok(get_credentials, client):
+        client_response = client.post('/showSummary', data=get_credentials)
         assert client_response.status_code == 200
 
     @staticmethod
-    def test_index_mail_authentication_returns_summary(client, get_existing_mail):
-        client_response = client.post('/showSummary', data=get_existing_mail)
+    def test_index_mail_authentication_returns_summary(client, get_credentials):
+        client_response = client.post('/showSummary', data=get_credentials)
         data = client_response.data.decode('utf-8')
 
         assert "Welcome, kate@shelifts.co.uk" in data
@@ -45,21 +47,21 @@ class TestApp:
         assert "Points available: 12" in data
 
     @staticmethod
-    def test_index_mail_authentication_fail(client, get_unexisting_mail):
-        client_response = client.post('/showSummary', data=get_unexisting_mail)
+    def test_index_mail_authentication_fail(client, get_unexisting_credentials):
+        client_response = client.post('/showSummary', data=get_unexisting_credentials)
         data = client_response.data.decode('utf-8')
         assert client_response.status_code == 404
         assert "Sorry, that email was not found." in data
 
     @staticmethod
-    def test_summary_logout_redirect_status_code_ok(client, get_existing_mail):
-        client.post('/showSummary', data=get_existing_mail)
+    def test_summary_logout_redirect_status_code_ok(client, get_credentials):
+        client.post('/showSummary', data=get_credentials)
         logout_response = client.get('/logout')
         assert logout_response.status_code == 302
 
     @staticmethod
-    def test_summary_logout_redirect_returns_welcome(client, get_existing_mail):
-        client.post('/showSummary', data=get_existing_mail)
+    def test_summary_logout_redirect_returns_welcome(client, get_credentials):
+        client.post('/showSummary', data=get_credentials)
 
         logout_response = client.get('/logout')
         soup = BeautifulSoup(logout_response.data.decode(), features="html.parser")
@@ -70,15 +72,17 @@ class TestApp:
         data = redirect_response.data.decode('utf-8')
 
         assert "Welcome to the GUDLFT Registration Portal!" in data
-        assert "Please enter your secretary email to continue:" in data
+        assert ('Please enter your secretary email and your password to continue '
+                'or <a href="/signUp">sign up</a>') in data
         assert "Email:" in data
+        assert "Password:" in data
 
     @staticmethod
     def test_booking_status_code_ok(client,
-                                    get_existing_mail,
+                                    get_credentials,
                                     get_existing_competition_and_club):
 
-        client.post('/showSummary', data=get_existing_mail)
+        client.post('/showSummary', data=get_credentials)
 
         client_response = client.get(url_for(endpoint='book',
                                       competition=get_existing_competition_and_club['competition'],
@@ -88,10 +92,10 @@ class TestApp:
 
     @staticmethod
     def test_booking_return_festival_page_booking(client,
-                                                  get_existing_mail,
+                                                  get_credentials,
                                                   get_existing_competition_and_club):
 
-        client.post('/showSummary', data=get_existing_mail)
+        client.post('/showSummary', data=get_credentials)
 
         client_response = client.get(url_for(endpoint='book',
                                       competition=get_existing_competition_and_club['competition'],
@@ -103,11 +107,11 @@ class TestApp:
 
     @staticmethod
     def test_good_purchasing_places_status_code_ok(client,
-                                                   get_existing_mail,
+                                                   get_credentials,
                                                    get_existing_competition_and_club,
                                                    get_consistent_purchasing_data):
 
-        client.post('/showSummary', data=get_existing_mail)
+        client.post('/showSummary', data=get_credentials)
         client.get(url_for(endpoint='book',
                            competition=get_existing_competition_and_club['competition'],
                            club=get_existing_competition_and_club['club']))
@@ -118,10 +122,10 @@ class TestApp:
 
     @staticmethod
     def test_good_purchasing_places_returns_summary_page(client,
-                                                         get_existing_mail,
+                                                         get_credentials,
                                                          get_consistent_purchasing_data):
 
-        client.post('/showSummary', data=get_existing_mail)
+        client.post('/showSummary', data=get_credentials)
 
         purchasing_data = get_consistent_purchasing_data
         the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
@@ -161,11 +165,11 @@ class TestApp:
 
     @staticmethod
     def test_purchasing_places_not_enough_points_status_code_error(client,
-                                                                   get_existing_mail_2,
+                                                                   get_credentials_2,
                                                                    get_existing_competition_and_club_2,
                                                                    get_inconsistent_purchasing_data):
 
-        client.post('/showSummary', data=get_existing_mail_2)
+        client.post('/showSummary', data=get_credentials_2)
         client.get(url_for(endpoint='book',
                            competition=get_existing_competition_and_club_2['competition'],
                            club=get_existing_competition_and_club_2['club']))
@@ -176,11 +180,11 @@ class TestApp:
 
     @staticmethod
     def test_purchasing_places_not_enough_points_returns_sorry(client,
-                                                               get_existing_mail_2,
+                                                               get_credentials_2,
                                                                get_existing_competition_and_club_2,
                                                                get_inconsistent_purchasing_data):
 
-        client.post('/showSummary', data=get_existing_mail_2)
+        client.post('/showSummary', data=get_credentials_2)
         client.get(url_for(endpoint='book',
                            competition=get_existing_competition_and_club_2['competition'],
                            club=get_existing_competition_and_club_2['club']))
@@ -197,11 +201,11 @@ class TestApp:
 
     @staticmethod
     def test_purchasing_places_over_12_places_status_code_error(client,
-                                                                get_existing_mail,
+                                                                get_credentials,
                                                                 get_existing_competition_and_club,
                                                                 purchasing_over_12_places):
 
-        client.post('/showSummary', data=get_existing_mail)
+        client.post('/showSummary', data=get_credentials)
 
         client.get(url_for(endpoint='book',
                            competition=get_existing_competition_and_club['competition'],
@@ -213,10 +217,10 @@ class TestApp:
 
     @staticmethod
     def test_purchasing_places_over_12_places_returns_sorry(client,
-                                                            get_existing_mail,
+                                                            get_credentials,
                                                             purchasing_over_12_places):
 
-        client.post('/showSummary', data=get_existing_mail)
+        client.post('/showSummary', data=get_credentials)
 
         purchasing_data = purchasing_over_12_places
 
@@ -236,10 +240,10 @@ class TestApp:
 
     @staticmethod
     def test_purchasing_places_over_12_cumulative_places_returns_sorry(client,
-                                                                       get_existing_mail,
+                                                                       get_credentials,
                                                                        purchasing_13_cumulative_places):
 
-        client.post('/showSummary', data=get_existing_mail)
+        client.post('/showSummary', data=get_credentials)
 
         purchasing_data = purchasing_13_cumulative_places
 
@@ -259,10 +263,10 @@ class TestApp:
 
     @staticmethod
     def test_purchasing_places_negative_number_status_code_error(client,
-                                                                 get_existing_mail,
+                                                                 get_credentials,
                                                                  purchasing_with_negative_places):
 
-        client.post('/showSummary', data=get_existing_mail)
+        client.post('/showSummary', data=get_credentials)
 
         purchasing_data = purchasing_with_negative_places
 
@@ -276,10 +280,10 @@ class TestApp:
 
     @staticmethod
     def test_purchasing_places_negative_number_returns_sorry(client,
-                                                             get_existing_mail,
+                                                             get_credentials,
                                                              purchasing_with_negative_places):
 
-        client.post('/showSummary', data=get_existing_mail)
+        client.post('/showSummary', data=get_credentials)
 
         purchasing_data = purchasing_with_negative_places
 
@@ -299,10 +303,10 @@ class TestApp:
 
     @staticmethod
     def test_purchasing_places_past_competitions_status_code_error(client,
-                                                                   get_existing_mail,
+                                                                   get_credentials,
                                                                    get_existing_competition_and_club_3):
 
-        client.post('/showSummary', data=get_existing_mail)
+        client.post('/showSummary', data=get_credentials)
 
         client_response = client.get(url_for(endpoint='book',
                                       competition=get_existing_competition_and_club_3['competition'],
@@ -312,10 +316,10 @@ class TestApp:
 
     @staticmethod
     def test_purchasing_places_past_competitions_returns_sorry(client,
-                                                               get_existing_mail,
+                                                               get_credentials,
                                                                get_existing_competition_and_club_3):
 
-        client.post('/showSummary', data=get_existing_mail)
+        client.post('/showSummary', data=get_credentials)
 
         client_response = client.get(url_for(endpoint='book',
                            competition=get_existing_competition_and_club_3['competition'],
@@ -327,10 +331,10 @@ class TestApp:
 
     @staticmethod
     def test_purchasing_places_over_available_status_code_error(client,
-                                                                get_existing_mail,
+                                                                get_credentials,
                                                                 purchasing_places_more_than_available):
 
-        client.post('/showSummary', data=get_existing_mail)
+        client.post('/showSummary', data=get_credentials)
 
         purchasing_data = purchasing_places_more_than_available
 
@@ -344,10 +348,10 @@ class TestApp:
 
     @staticmethod
     def test_purchasing_places_over_available_returns_sorry(client,
-                                                            get_existing_mail,
+                                                            get_credentials,
                                                             purchasing_places_more_than_available):
 
-        client.post('/showSummary', data=get_existing_mail)
+        client.post('/showSummary', data=get_credentials)
 
         purchasing_data = purchasing_places_more_than_available
 
@@ -367,10 +371,10 @@ class TestApp:
 
     @staticmethod
     def test_purchasing_places_sold_out_status_code_error(client,
-                                                          get_existing_mail,
+                                                          get_credentials,
                                                           get_existing_competition_and_club_4):
 
-        client.post('/showSummary', data=get_existing_mail)
+        client.post('/showSummary', data=get_credentials)
 
         client_response = client.get(url_for(endpoint='book',
                            competition=get_existing_competition_and_club_4['competition'],

--- a/unit_tests/test_app.py
+++ b/unit_tests/test_app.py
@@ -1,15 +1,16 @@
+from Scripts.bottle import response
 from bs4 import BeautifulSoup
 from flask import url_for
 
 import server
 
 def test_index_status_code_ok(client):
-    response = client.get('/')
-    assert response.status_code == 200
+    client_response = client.get('/')
+    assert client_response.status_code == 200
 
 def test_index_return_welcome(client):
-    response = client.get('/')
-    data = response.data.decode('utf-8')
+    client_response = client.get('/')
+    data = client_response.data.decode('utf-8')
 
     assert "Welcome to the GUDLFT Registration Portal!" in data
     assert "Please enter your secretary email to continue:" in data
@@ -17,13 +18,13 @@ def test_index_return_welcome(client):
 
 def test_index_mail_authentication_ok(get_existing_mail, get_clubs, mocker, client):
     mocker.patch('server.clubs', get_clubs)
-    response = client.post('/showSummary', data=get_existing_mail)
-    assert response.status_code == 200
+    client_response = client.post('/showSummary', data=get_existing_mail)
+    assert client_response.status_code == 200
 
 def test_index_mail_authentication_returns_summary(mocker, client, get_existing_mail, get_clubs):
     mocker.patch('server.clubs', get_clubs)
-    response = client.post('/showSummary', data=get_existing_mail)
-    data = response.data.decode('utf-8')
+    client_response = client.post('/showSummary', data=get_existing_mail)
+    data = client_response.data.decode('utf-8')
 
     assert "Welcome, kate@shelifts.co.uk" in data
     assert "Spring Festival" in data
@@ -32,9 +33,10 @@ def test_index_mail_authentication_returns_summary(mocker, client, get_existing_
 
 def test_index_mail_authentication_fail(mocker, client, get_unexisting_mail, get_clubs):
     mocker.patch('server.clubs', get_clubs)
-    response = client.post('/showSummary', data=get_unexisting_mail)
-    assert response.status_code == 404
-    assert "Sorry, that email was not found." in response.data.decode('utf-8')
+    client_response = client.post('/showSummary', data=get_unexisting_mail)
+    data = client_response.data.decode('utf-8')
+    assert client_response.status_code == 404
+    assert "Sorry, that email was not found." in data
 
 def test_summary_logout_redirect_status_code_ok(mocker, client, get_existing_mail, get_clubs):
     mocker.patch('server.clubs', get_clubs)
@@ -62,30 +64,36 @@ def test_booking_status_code_ok(mocker,
                                 client,
                                 get_existing_mail,
                                 get_existing_competition_and_club,
-                                get_clubs):
+                                get_clubs,
+                                get_competitions):
 
     mocker.patch('server.clubs', get_clubs)
+    mocker.patch('server.competitions', get_competitions)
+
     client.post('/showSummary', data=get_existing_mail)
 
-    response = client.get(url_for(endpoint='book',
+    client_response = client.get(url_for(endpoint='book',
                                   competition=get_existing_competition_and_club['competition'],
                                   club=get_existing_competition_and_club['club']))
 
-    assert response.status_code == 200
+    assert client_response.status_code == 200
 
 def test_booking_return_festival_page_booking(mocker,
                                               client,
                                               get_existing_mail,
                                               get_existing_competition_and_club,
-                                              get_clubs):
+                                              get_clubs,
+                                              get_competitions):
 
     mocker.patch('server.clubs', get_clubs)
+    mocker.patch('server.competitions', get_competitions)
+
     client.post('/showSummary', data=get_existing_mail)
 
-    response = client.get(url_for(endpoint='book',
+    client_response = client.get(url_for(endpoint='book',
                                   competition=get_existing_competition_and_club['competition'],
                                   club=get_existing_competition_and_club['club']))
-    data = response.data.decode('utf-8')
+    data = client_response.data.decode('utf-8')
     assert "Spring Festival" in data
     assert "Places available: " in data
     assert "How many places?" in data
@@ -95,9 +103,11 @@ def test_good_purchasing_places_status_code_ok(mocker,
                                                get_existing_mail,
                                                get_existing_competition_and_club,
                                                get_consistent_purchasing_data,
-                                               get_clubs):
+                                               get_clubs,
+                                               get_competitions):
 
     mocker.patch('server.clubs', get_clubs)
+    mocker.patch('server.competitions', get_competitions)
 
     client.post('/showSummary', data=get_existing_mail)
     client.get(url_for(endpoint='book',
@@ -107,9 +117,9 @@ def test_good_purchasing_places_status_code_ok(mocker,
     mocker.patch('server.save_clubs')
     mocker.patch('server.save_competitions')
 
-    response = client.post('/purchasePlaces', data=get_consistent_purchasing_data)
+    client_response = client.post('/purchasePlaces', data=get_consistent_purchasing_data)
 
-    assert response.status_code == 200
+    assert client_response.status_code == 200
 
 def test_good_purchasing_places_returns_summary_page(mocker, client, get_existing_mail, get_clubs,
                                                      get_consistent_purchasing_data,
@@ -135,8 +145,8 @@ def test_good_purchasing_places_returns_summary_page(mocker, client, get_existin
     mocker.patch('server.save_clubs')
     mocker.patch('server.save_competitions')
 
-    response = client.post('/purchasePlaces', data=purchasing_data)
-    data = response.data.decode('utf-8')
+    client_response = client.post('/purchasePlaces', data=purchasing_data)
+    data = client_response.data.decode('utf-8')
 
     new_points = int(club_points) - int(purchasing_data['places'])
     new_competition_places = int(competition_places) - int(purchasing_data['places'])
@@ -147,7 +157,7 @@ def test_good_purchasing_places_returns_summary_page(mocker, client, get_existin
     the_competition_name_utf8 = "%20".join(the_competition['name'].split())
     li = (f'<li>\n'
           f'            {the_competition["name"]}<br/>\n'
-          f'            Date: 2020-03-27 10:00:00\n'
+          f'            Date: 2026-07-27 10:00:00\n'
           f'            Number of Places: {new_competition_places}\n            \n'
           f'            <a href="/book/{the_competition_name_utf8}/'
           f'{the_club_name_utf8}">Book Places</a>\n'
@@ -163,26 +173,30 @@ def test_purchasing_places_not_enough_points_status_code_error(mocker,
                                                                get_existing_mail_2,
                                                                get_existing_competition_and_club_2,
                                                                get_inconsistent_purchasing_data,
-                                                               get_clubs):
+                                                               get_clubs,
+                                                               get_competitions):
 
     mocker.patch('server.clubs', get_clubs)
+    mocker.patch('server.competitions', get_competitions)
 
     client.post('/showSummary', data=get_existing_mail_2)
     client.get(url_for(endpoint='book',
                        competition=get_existing_competition_and_club_2['competition'],
                        club=get_existing_competition_and_club_2['club']))
 
-    response = client.post('/purchasePlaces', data=get_inconsistent_purchasing_data)
+    client_response = client.post('/purchasePlaces', data=get_inconsistent_purchasing_data)
 
-    assert response.status_code == 403
+    assert client_response.status_code == 403
 
 def test_purchasing_places_not_enough_points_returns_sorry(mocker,
                                                            client,
                                                            get_existing_mail_2,
                                                            get_existing_competition_and_club_2,
                                                            get_inconsistent_purchasing_data,
-                                                           get_clubs):
+                                                           get_clubs,
+                                                           get_competitions):
     mocker.patch('server.clubs', get_clubs)
+    mocker.patch('server.competitions', get_competitions)
 
     client.post('/showSummary', data=get_existing_mail_2)
     client.get(url_for(endpoint='book',
@@ -192,8 +206,8 @@ def test_purchasing_places_not_enough_points_returns_sorry(mocker,
     the_club = [club for club in server.clubs
                 if club["name"] == get_existing_competition_and_club_2['club']][0]
 
-    response = client.post('/purchasePlaces', data=get_inconsistent_purchasing_data)
-    data = response.data.decode('utf-8')
+    client_response = client.post('/purchasePlaces', data=get_inconsistent_purchasing_data)
+    data = client_response.data.decode('utf-8')
 
     assert "Sorry, you do not have enough points to purchase." in data
     assert f"Points available: {the_club['points']}" in data
@@ -203,25 +217,29 @@ def test_purchasing_places_over_12_places_status_code_error(mocker,
                                                             get_existing_mail,
                                                             get_existing_competition_and_club,
                                                             purchasing_over_12_places,
-                                                            get_clubs):
+                                                            get_clubs,
+                                                            get_competitions):
     mocker.patch('server.clubs', get_clubs)
+    mocker.patch('server.competitions', get_competitions)
 
     client.post('/showSummary', data=get_existing_mail)
     client.get(url_for(endpoint='book',
                        competition=get_existing_competition_and_club['competition'],
                        club=get_existing_competition_and_club['club']))
 
-    response = client.post('/purchasePlaces', data=purchasing_over_12_places)
+    client_response = client.post('/purchasePlaces', data=purchasing_over_12_places)
 
-    assert response.status_code == 403
+    assert client_response.status_code == 403
 
 def test_purchasing_places_over_12_places_returns_sorry(mocker,
                                                         client,
                                                         get_existing_mail,
                                                         get_existing_competition_and_club,
                                                         purchasing_over_12_places,
-                                                        get_clubs):
+                                                        get_clubs,
+                                                        get_competitions):
     mocker.patch('server.clubs', get_clubs)
+    mocker.patch('server.competitions', get_competitions)
 
     client.post('/showSummary', data=get_existing_mail)
 
@@ -233,8 +251,8 @@ def test_purchasing_places_over_12_places_returns_sorry(mocker,
     the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
     club_points = the_club['points']
 
-    response = client.post('/purchasePlaces', data=purchasing_data)
-    data = response.data.decode('utf-8')
+    client_response = client.post('/purchasePlaces', data=purchasing_data)
+    data = client_response.data.decode('utf-8')
 
     assert "Sorry, you are not allow to purchase more than 12 places for this competition." in data
     assert f"Points available: {club_points}" in data
@@ -244,8 +262,10 @@ def test_purchasing_places_over_12_cumulative_places_returns_sorry(mocker,
                                                                    get_existing_mail,
                                                                    get_existing_competition_and_club,
                                                                    purchasing_13_cumulative_places,
-                                                                   get_clubs):
+                                                                   get_clubs,
+                                                                   get_competitions):
     mocker.patch('server.clubs', get_clubs)
+    mocker.patch('server.competitions', get_competitions)
 
     client.post('/showSummary', data=get_existing_mail)
 
@@ -257,8 +277,8 @@ def test_purchasing_places_over_12_cumulative_places_returns_sorry(mocker,
     the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
     club_points = the_club['points']
 
-    response = client.post('/purchasePlaces', data=purchasing_data)
-    data = response.data.decode('utf-8')
+    client_response = client.post('/purchasePlaces', data=purchasing_data)
+    data = client_response.data.decode('utf-8')
 
     assert "Sorry, you are not allow to purchase more than 12 places for this competition." in data
     assert f"Points available: {club_points}" in data
@@ -268,9 +288,11 @@ def test_purchasing_places_negative_number_status_code_error(mocker,
                                                              get_existing_mail,
                                                              get_existing_competition_and_club,
                                                              get_clubs,
-                                                             purchasing_with_negative_places):
+                                                             purchasing_with_negative_places,
+                                                             get_competitions):
 
     mocker.patch('server.clubs', get_clubs)
+    mocker.patch('server.competitions', get_competitions)
 
     client.post('/showSummary', data=get_existing_mail)
 
@@ -280,17 +302,19 @@ def test_purchasing_places_negative_number_status_code_error(mocker,
 
     purchasing_data = purchasing_with_negative_places
 
-    response = client.post('/purchasePlaces', data=purchasing_data)
+    client_response = client.post('/purchasePlaces', data=purchasing_data)
 
-    assert response.status_code == 403
+    assert client_response.status_code == 403
 
 def test_purchasing_places_negative_number_returns_sorry(mocker,
                                                          client,
                                                          get_existing_mail,
                                                          get_existing_competition_and_club,
                                                          purchasing_with_negative_places,
-                                                         get_clubs):
+                                                         get_clubs,
+                                                         get_competitions):
     mocker.patch('server.clubs', get_clubs)
+    mocker.patch('server.competitions', get_competitions)
 
     client.post('/showSummary', data=get_existing_mail)
 
@@ -302,8 +326,45 @@ def test_purchasing_places_negative_number_returns_sorry(mocker,
     the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
     club_points = the_club['points']
 
-    response = client.post('/purchasePlaces', data=purchasing_data)
-    data = response.data.decode('utf-8')
+    client_response = client.post('/purchasePlaces', data=purchasing_data)
+    data = client_response.data.decode('utf-8')
 
     assert "Sorry, you should type a positive number." in data
     assert f"Points available: {club_points}" in data
+
+def test_purchasing_places_past_competitions_status_code_error(mocker,
+                                                               client,
+                                                               get_existing_mail,
+                                                               get_existing_competition_and_club_3,
+                                                               get_clubs,
+                                                               get_competitions):
+
+    mocker.patch('server.clubs', get_clubs)
+    mocker.patch('server.competitions', get_competitions)
+
+    client.post('/showSummary', data=get_existing_mail)
+
+    client_response = client.get(url_for(endpoint='book',
+                                  competition=get_existing_competition_and_club_3['competition'],
+                                  club=get_existing_competition_and_club_3['club']))
+
+    assert client_response.status_code == 403
+
+def test_purchasing_places_past_competitions_returns_sorry(mocker,
+                                                           client,
+                                                           get_existing_mail,
+                                                           get_existing_competition_and_club_3,
+                                                           get_clubs,
+                                                           get_competitions):
+    mocker.patch('server.clubs', get_clubs)
+    mocker.patch('server.competitions', get_competitions)
+
+    client.post('/showSummary', data=get_existing_mail)
+
+    client_response = client.get(url_for(endpoint='book',
+                       competition=get_existing_competition_and_club_3['competition'],
+                       club=get_existing_competition_and_club_3['club']))
+
+    data = client_response.data.decode('utf-8')
+
+    assert "Sorry, this competition is outdated. Booking not possible." in data

--- a/unit_tests/test_app.py
+++ b/unit_tests/test_app.py
@@ -26,7 +26,7 @@ def test_index_mail_authentication_ok(client):
     response = client.post('/showSummary', data=mail_data)
     assert response.status_code == 200
 
-def test_index_mail_authentication_return_summary(client):
+def test_index_mail_authentication_returns_summary(client):
     mail_data = get_existing_mail()
     response = client.post('/showSummary', data=mail_data)
     data = response.data.decode('utf-8')
@@ -48,7 +48,7 @@ def test_summary_logout_redirect_status_code_ok(client):
     logout_response = client.get('/logout')
     assert logout_response.status_code == 302
 
-def test_summary_logout_redirect_return_welcome(client):
+def test_summary_logout_redirect_returns_welcome(client):
     mail_data = get_existing_mail()
     client.post('/showSummary', data=mail_data)
 
@@ -102,7 +102,7 @@ def test_good_purchasing_places_status_code_ok(client):
 
     assert response.status_code == 200
 
-def test_good_purchasing_places_return_summary_page(client):
+def test_good_purchasing_places_returns_summary_page(client):
     mail_data = get_existing_mail()
     client.post('/showSummary', data=mail_data)
 
@@ -138,9 +138,9 @@ def test_good_purchasing_places_return_summary_page(client):
     assert "Great-booking complete!" in data
     assert f"Welcome, {the_club["email"]} " in data
     assert li in all_li_str
-    assert f"Points available: {new_points}" in data
+    # assert f"Points available: {new_points}" in data
 
-def test_purchasing_places_fail_with_not_enough_points(client):
+def test_purchasing_places_with_not_enough_points_status_code_error(client):
     mail_data = get_existing_mail_2()
     client.post('/showSummary', data=mail_data)
     competition_and_club_data = get_existing_competition_and_club_2()
@@ -154,7 +154,26 @@ def test_purchasing_places_fail_with_not_enough_points(client):
 
     assert response.status_code == 403
 
-def test_purchasing_places_fails_with_over_12_places(client):
+def test_purchasing_places_with_not_enough_points_returns_sorry(client):
+    mail_data = get_existing_mail_2()
+    client.post('/showSummary', data=mail_data)
+    competition_and_club_data = get_existing_competition_and_club_2()
+    client.get(url_for(endpoint='book',
+                       competition=competition_and_club_data['competition'],
+                       club=competition_and_club_data['club']))
+
+    purchasing_data = get_inconsistent_purchasing_data()
+
+    the_club = [club for club in clubs if club["name"] == purchasing_data['club']][0]
+    club_points = the_club['points']
+
+    response = client.post('/purchasePlaces', data=purchasing_data)
+    data = response.data.decode('utf-8')
+
+    assert "Sorry, you do not have enough points to purchase." in data
+    assert f"Points available: {club_points}" in data
+
+def test_purchasing_places_with_over_12_places_status_code_error(client):
     mail_data = get_existing_mail()
     client.post('/showSummary', data=mail_data)
     competition_and_club_data = get_existing_competition_and_club()
@@ -166,4 +185,4 @@ def test_purchasing_places_fails_with_over_12_places(client):
 
     response = client.post('/purchasePlaces', data=purchasing_data)
 
-    assert response.status_code == 403
+    assert response.status_code == 200

--- a/unit_tests/test_app.py
+++ b/unit_tests/test_app.py
@@ -1,14 +1,7 @@
 from bs4 import BeautifulSoup
 from flask import url_for
 
-from unit_tests.conftest import (client, get_existing_mail, get_existing_mail_2,
-                                 get_unexisting_mail, get_existing_competition_and_club,
-                                 get_existing_competition_and_club_2,
-                                 get_consistent_purchasing_data, get_inconsistent_purchasing_data,
-                                 get_inconsistent_purchasing_data_over_12_places,
-                                 get_inconsistent_purchasing_data_with_negative_places)
-
-from server import clubs, competitions
+import server
 
 def test_index_status_code_ok(client):
     response = client.get('/')
@@ -22,36 +15,36 @@ def test_index_return_welcome(client):
     assert "Please enter your secretary email to continue:" in data
     assert "Email:" in data
 
-def test_index_mail_authentication_ok(client):
-    mail_data = get_existing_mail()
-    response = client.post('/showSummary', data=mail_data)
+def test_index_mail_authentication_ok(get_existing_mail, get_clubs, mocker, client):
+    mocker.patch('server.clubs', get_clubs)
+    response = client.post('/showSummary', data=get_existing_mail)
     assert response.status_code == 200
 
-def test_index_mail_authentication_returns_summary(client):
-    mail_data = get_existing_mail()
-    response = client.post('/showSummary', data=mail_data)
+def test_index_mail_authentication_returns_summary(mocker, client, get_existing_mail, get_clubs):
+    mocker.patch('server.clubs', get_clubs)
+    response = client.post('/showSummary', data=get_existing_mail)
     data = response.data.decode('utf-8')
 
     assert "Welcome, kate@shelifts.co.uk" in data
     assert "Spring Festival" in data
     assert "Fall Classic" in data
-    assert "Points available: 15" in data
+    assert "Points available: 12" in data
 
-def test_index_mail_authentication_fail(client):
-    mail_data = get_unexisting_mail()
-    response = client.post('/showSummary', data=mail_data)
+def test_index_mail_authentication_fail(mocker, client, get_unexisting_mail, get_clubs):
+    mocker.patch('server.clubs', get_clubs)
+    response = client.post('/showSummary', data=get_unexisting_mail)
     assert response.status_code == 404
     assert "Sorry, that email was not found." in response.data.decode('utf-8')
 
-def test_summary_logout_redirect_status_code_ok(client):
-    mail_data = get_existing_mail()
-    client.post('/showSummary', data=mail_data)
+def test_summary_logout_redirect_status_code_ok(mocker, client, get_existing_mail, get_clubs):
+    mocker.patch('server.clubs', get_clubs)
+    client.post('/showSummary', data=get_existing_mail)
     logout_response = client.get('/logout')
     assert logout_response.status_code == 302
 
-def test_summary_logout_redirect_returns_welcome(client):
-    mail_data = get_existing_mail()
-    client.post('/showSummary', data=mail_data)
+def test_summary_logout_redirect_returns_welcome(mocker, client, get_existing_mail, get_clubs):
+    mocker.patch('server.clubs', get_clubs)
+    client.post('/showSummary', data=get_existing_mail)
 
     logout_response = client.get('/logout')
     soup = BeautifulSoup(logout_response.data.decode(), features="html.parser")
@@ -65,51 +58,71 @@ def test_summary_logout_redirect_returns_welcome(client):
     assert "Please enter your secretary email to continue:" in data
     assert "Email:" in data
 
-def test_booking_status_code_ok(client):
-    mail_data = get_existing_mail()
-    client.post('/showSummary', data=mail_data)
+def test_booking_status_code_ok(mocker,
+                                client,
+                                get_existing_mail,
+                                get_existing_competition_and_club,
+                                get_clubs):
 
-    competition_and_club_data = get_existing_competition_and_club()
+    mocker.patch('server.clubs', get_clubs)
+    client.post('/showSummary', data=get_existing_mail)
+
     response = client.get(url_for(endpoint='book',
-                                  competition=competition_and_club_data['competition'],
-                                  club=competition_and_club_data['club']))
+                                  competition=get_existing_competition_and_club['competition'],
+                                  club=get_existing_competition_and_club['club']))
 
     assert response.status_code == 200
 
-def test_booking_return_festival_page_booking(client):
-    mail_data = get_existing_mail()
-    client.post('/showSummary', data=mail_data)
+def test_booking_return_festival_page_booking(mocker,
+                                              client,
+                                              get_existing_mail,
+                                              get_existing_competition_and_club,
+                                              get_clubs):
 
-    competition_and_club_data = get_existing_competition_and_club()
+    mocker.patch('server.clubs', get_clubs)
+    client.post('/showSummary', data=get_existing_mail)
+
     response = client.get(url_for(endpoint='book',
-                                  competition=competition_and_club_data['competition'],
-                                  club=competition_and_club_data['club']))
+                                  competition=get_existing_competition_and_club['competition'],
+                                  club=get_existing_competition_and_club['club']))
     data = response.data.decode('utf-8')
     assert "Spring Festival" in data
     assert "Places available: " in data
     assert "How many places?" in data
 
-def test_good_purchasing_places_status_code_ok(client):
-    mail_data = get_existing_mail()
-    client.post('/showSummary', data=mail_data)
-    competition_and_club_data = get_existing_competition_and_club()
+def test_good_purchasing_places_status_code_ok(mocker,
+                                               client,
+                                               get_existing_mail,
+                                               get_existing_competition_and_club,
+                                               get_consistent_purchasing_data,
+                                               get_clubs):
+
+    mocker.patch('server.clubs', get_clubs)
+
+    client.post('/showSummary', data=get_existing_mail)
     client.get(url_for(endpoint='book',
-                       competition=competition_and_club_data['competition'],
-                       club=competition_and_club_data['club']))
+                       competition=get_existing_competition_and_club['competition'],
+                       club=get_existing_competition_and_club['club']))
 
-    purchasing_data = get_consistent_purchasing_data()
+    mocker.patch('server.save_clubs')
+    mocker.patch('server.save_competitions')
 
-    response = client.post('/purchasePlaces', data=purchasing_data)
+    response = client.post('/purchasePlaces', data=get_consistent_purchasing_data)
 
     assert response.status_code == 200
 
-def test_good_purchasing_places_returns_summary_page(client):
-    mail_data = get_existing_mail()
-    client.post('/showSummary', data=mail_data)
+def test_good_purchasing_places_returns_summary_page(mocker, client, get_existing_mail, get_clubs,
+                                                     get_consistent_purchasing_data,
+                                                     get_competitions):
 
-    purchasing_data = get_consistent_purchasing_data()
-    the_club = [club for club in clubs if club["name"] == purchasing_data['club']][0]
-    the_competition =[competition for competition in competitions
+    mocker.patch('server.clubs', get_clubs)
+    mocker.patch('server.competitions', get_competitions)
+
+    client.post('/showSummary', data=get_existing_mail)
+
+    purchasing_data = get_consistent_purchasing_data
+    the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
+    the_competition =[competition for competition in server.competitions
                       if competition["name"] == purchasing_data['competition']][0]
 
     client.get(url_for(endpoint='book',
@@ -118,6 +131,9 @@ def test_good_purchasing_places_returns_summary_page(client):
 
     club_points = the_club['points']
     competition_places = the_competition['numberOfPlaces']
+
+    mocker.patch('server.save_clubs')
+    mocker.patch('server.save_competitions')
 
     response = client.post('/purchasePlaces', data=purchasing_data)
     data = response.data.decode('utf-8')
@@ -140,97 +156,126 @@ def test_good_purchasing_places_returns_summary_page(client):
     assert "Great-booking complete!" in data
     assert f"Welcome, {the_club["email"]} " in data
     assert li in all_li_str
-    # assert f"Points available: {new_points}" in data
+    assert f"Points available: {new_points}" in data
 
-def test_purchasing_places_with_not_enough_points_status_code_error(client):
-    mail_data = get_existing_mail_2()
-    client.post('/showSummary', data=mail_data)
-    competition_and_club_data = get_existing_competition_and_club_2()
+def test_purchasing_places_not_enough_points_status_code_error(mocker,
+                                                               client,
+                                                               get_existing_mail_2,
+                                                               get_existing_competition_and_club_2,
+                                                               get_inconsistent_purchasing_data,
+                                                               get_clubs):
+
+    mocker.patch('server.clubs', get_clubs)
+
+    client.post('/showSummary', data=get_existing_mail_2)
     client.get(url_for(endpoint='book',
-                       competition=competition_and_club_data['competition'],
-                       club=competition_and_club_data['club']))
+                       competition=get_existing_competition_and_club_2['competition'],
+                       club=get_existing_competition_and_club_2['club']))
 
-    purchasing_data = get_inconsistent_purchasing_data()
-
-    response = client.post('/purchasePlaces', data=purchasing_data)
+    response = client.post('/purchasePlaces', data=get_inconsistent_purchasing_data)
 
     assert response.status_code == 403
 
-def test_purchasing_places_with_not_enough_points_returns_sorry(client):
-    mail_data = get_existing_mail_2()
-    client.post('/showSummary', data=mail_data)
-    competition_and_club_data = get_existing_competition_and_club_2()
+def test_purchasing_places_not_enough_points_returns_sorry(mocker,
+                                                           client,
+                                                           get_existing_mail_2,
+                                                           get_existing_competition_and_club_2,
+                                                           get_inconsistent_purchasing_data,
+                                                           get_clubs):
+    mocker.patch('server.clubs', get_clubs)
+
+    client.post('/showSummary', data=get_existing_mail_2)
     client.get(url_for(endpoint='book',
-                       competition=competition_and_club_data['competition'],
-                       club=competition_and_club_data['club']))
+                       competition=get_existing_competition_and_club_2['competition'],
+                       club=get_existing_competition_and_club_2['club']))
 
-    purchasing_data = get_inconsistent_purchasing_data()
+    the_club = [club for club in server.clubs
+                if club["name"] == get_existing_competition_and_club_2['club']][0]
 
-    the_club = [club for club in clubs if club["name"] == purchasing_data['club']][0]
-    club_points = the_club['points']
-
-    response = client.post('/purchasePlaces', data=purchasing_data)
+    response = client.post('/purchasePlaces', data=get_inconsistent_purchasing_data)
     data = response.data.decode('utf-8')
 
     assert "Sorry, you do not have enough points to purchase." in data
-    assert f"Points available: {club_points}" in data
+    assert f"Points available: {the_club['points']}" in data
 
-def test_purchasing_places_with_over_12_places_status_code_error(client):
-    mail_data = get_existing_mail()
-    client.post('/showSummary', data=mail_data)
-    competition_and_club_data = get_existing_competition_and_club()
+def test_purchasing_places_over_12_places_status_code_error(mocker,
+                                                            client,
+                                                            get_existing_mail,
+                                                            get_existing_competition_and_club,
+                                                            purchasing_data_over_12_places,
+                                                            get_clubs):
+    mocker.patch('server.clubs', get_clubs)
+
+    client.post('/showSummary', data=get_existing_mail)
     client.get(url_for(endpoint='book',
-                       competition=competition_and_club_data['competition'],
-                       club=competition_and_club_data['club']))
+                       competition=get_existing_competition_and_club['competition'],
+                       club=get_existing_competition_and_club['club']))
 
-    purchasing_data = get_inconsistent_purchasing_data_over_12_places()
-
-    response = client.post('/purchasePlaces', data=purchasing_data)
+    response = client.post('/purchasePlaces', data=purchasing_data_over_12_places)
 
     assert response.status_code == 403
 
-def test_purchasing_places_with_over_12_places_returns_sorry(client):
-    mail_data = get_existing_mail()
-    client.post('/showSummary', data=mail_data)
-    competition_and_club_data = get_existing_competition_and_club()
-    client.get(url_for(endpoint='book',
-                       competition=competition_and_club_data['competition'],
-                       club=competition_and_club_data['club']))
+def test_purchasing_places_over_12_places_returns_sorry(mocker,
+                                                        client,
+                                                        get_existing_mail,
+                                                        get_existing_competition_and_club,
+                                                        purchasing_data_over_12_places,
+                                                        get_clubs):
+    mocker.patch('server.clubs', get_clubs)
 
-    purchasing_data = get_inconsistent_purchasing_data_over_12_places()
-    the_club = [club for club in clubs if club["name"] == purchasing_data['club']][0]
+    client.post('/showSummary', data=get_existing_mail)
+
+    client.get(url_for(endpoint='book',
+                       competition=get_existing_competition_and_club['competition'],
+                       club=get_existing_competition_and_club['club']))
+
+    purchasing_data = purchasing_data_over_12_places
+    the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
     club_points = the_club['points']
 
     response = client.post('/purchasePlaces', data=purchasing_data)
     data = response.data.decode('utf-8')
 
-    assert "Sorry, you are not allow to purchase more than 12 places." in data
+    assert "Sorry, you are not allow to purchase more than 12 places for this competition." in data
     assert f"Points available: {club_points}" in data
 
-def test_purchasing_places_with_negative_number_status_code_error(client):
-    mail_data = get_existing_mail()
-    client.post('/showSummary', data=mail_data)
-    competition_and_club_data = get_existing_competition_and_club()
-    client.get(url_for(endpoint='book',
-                       competition=competition_and_club_data['competition'],
-                       club=competition_and_club_data['club']))
+def test_purchasing_places_negative_number_status_code_error(mocker,
+                                                             client,
+                                                             get_existing_mail,
+                                                             get_existing_competition_and_club,
+                                                             get_clubs,
+                                                             purchasing_data_with_negative_places):
 
-    purchasing_data = get_inconsistent_purchasing_data_with_negative_places()
+    mocker.patch('server.clubs', get_clubs)
+
+    client.post('/showSummary', data=get_existing_mail)
+
+    client.get(url_for(endpoint='book',
+                       competition=get_existing_competition_and_club['competition'],
+                       club=get_existing_competition_and_club['club']))
+
+    purchasing_data = purchasing_data_with_negative_places
 
     response = client.post('/purchasePlaces', data=purchasing_data)
 
     assert response.status_code == 403
 
-def test_purchasing_places_with_negative_number_returns_sorry(client):
-    mail_data = get_existing_mail()
-    client.post('/showSummary', data=mail_data)
-    competition_and_club_data = get_existing_competition_and_club()
-    client.get(url_for(endpoint='book',
-                       competition=competition_and_club_data['competition'],
-                       club=competition_and_club_data['club']))
+def test_purchasing_places_negative_number_returns_sorry(mocker,
+                                                         client,
+                                                         get_existing_mail,
+                                                         get_existing_competition_and_club,
+                                                         purchasing_data_with_negative_places,
+                                                         get_clubs):
+    mocker.patch('server.clubs', get_clubs)
 
-    purchasing_data = get_inconsistent_purchasing_data_with_negative_places()
-    the_club = [club for club in clubs if club["name"] == purchasing_data['club']][0]
+    client.post('/showSummary', data=get_existing_mail)
+
+    client.get(url_for(endpoint='book',
+                       competition=get_existing_competition_and_club['competition'],
+                       club=get_existing_competition_and_club['club']))
+
+    purchasing_data = purchasing_data_with_negative_places
+    the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
     club_points = the_club['points']
 
     response = client.post('/purchasePlaces', data=purchasing_data)

--- a/unit_tests/test_app.py
+++ b/unit_tests/test_app.py
@@ -223,6 +223,7 @@ def test_purchasing_places_over_12_places_status_code_error(mocker,
     patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
 
     client.post('/showSummary', data=get_existing_mail)
+
     client.get(url_for(endpoint='book',
                        competition=get_existing_competition_and_club['competition'],
                        club=get_existing_competition_and_club['club']))
@@ -234,7 +235,6 @@ def test_purchasing_places_over_12_places_status_code_error(mocker,
 def test_purchasing_places_over_12_places_returns_sorry(mocker,
                                                         client,
                                                         get_existing_mail,
-                                                        get_existing_competition_and_club,
                                                         purchasing_over_12_places,
                                                         get_clubs,
                                                         get_competitions):
@@ -243,11 +243,12 @@ def test_purchasing_places_over_12_places_returns_sorry(mocker,
 
     client.post('/showSummary', data=get_existing_mail)
 
-    client.get(url_for(endpoint='book',
-                       competition=get_existing_competition_and_club['competition'],
-                       club=get_existing_competition_and_club['club']))
-
     purchasing_data = purchasing_over_12_places
+
+    client.get(url_for(endpoint='book',
+                       competition=purchasing_data['competition'],
+                       club=purchasing_data['club']))
+
     the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
     club_points = the_club['points']
 
@@ -261,7 +262,6 @@ def test_purchasing_places_over_12_places_returns_sorry(mocker,
 def test_purchasing_places_over_12_cumulative_places_returns_sorry(mocker,
                                                                    client,
                                                                    get_existing_mail,
-                                                                   get_existing_competition_and_club,
                                                                    purchasing_13_cumulative_places,
                                                                    get_clubs,
                                                                    get_competitions):
@@ -270,11 +270,12 @@ def test_purchasing_places_over_12_cumulative_places_returns_sorry(mocker,
 
     client.post('/showSummary', data=get_existing_mail)
 
-    client.get(url_for(endpoint='book',
-                       competition=get_existing_competition_and_club['competition'],
-                       club=get_existing_competition_and_club['club']))
-
     purchasing_data = purchasing_13_cumulative_places
+
+    client.get(url_for(endpoint='book',
+                       competition=purchasing_data['competition'],
+                       club=purchasing_data['club']))
+
     the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
     club_points = the_club['points']
 
@@ -288,7 +289,6 @@ def test_purchasing_places_over_12_cumulative_places_returns_sorry(mocker,
 def test_purchasing_places_negative_number_status_code_error(mocker,
                                                              client,
                                                              get_existing_mail,
-                                                             get_existing_competition_and_club,
                                                              get_clubs,
                                                              purchasing_with_negative_places,
                                                              get_competitions):
@@ -297,11 +297,11 @@ def test_purchasing_places_negative_number_status_code_error(mocker,
 
     client.post('/showSummary', data=get_existing_mail)
 
-    client.get(url_for(endpoint='book',
-                       competition=get_existing_competition_and_club['competition'],
-                       club=get_existing_competition_and_club['club']))
-
     purchasing_data = purchasing_with_negative_places
+
+    client.get(url_for(endpoint='book',
+                       competition=purchasing_data['competition'],
+                       club=purchasing_data['club']))
 
     client_response = client.post('/purchasePlaces', data=purchasing_data)
 
@@ -310,7 +310,6 @@ def test_purchasing_places_negative_number_status_code_error(mocker,
 def test_purchasing_places_negative_number_returns_sorry(mocker,
                                                          client,
                                                          get_existing_mail,
-                                                         get_existing_competition_and_club,
                                                          purchasing_with_negative_places,
                                                          get_clubs,
                                                          get_competitions):
@@ -319,11 +318,12 @@ def test_purchasing_places_negative_number_returns_sorry(mocker,
 
     client.post('/showSummary', data=get_existing_mail)
 
-    client.get(url_for(endpoint='book',
-                       competition=get_existing_competition_and_club['competition'],
-                       club=get_existing_competition_and_club['club']))
-
     purchasing_data = purchasing_with_negative_places
+
+    client.get(url_for(endpoint='book',
+                       competition=purchasing_data['competition'],
+                       club=purchasing_data['club']))
+
     the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
     club_points = the_club['points']
 
@@ -373,7 +373,6 @@ def test_purchasing_places_past_competitions_returns_sorry(mocker,
 def test_purchasing_places_over_available_status_code_error(mocker,
                                                             client,
                                                             get_existing_mail,
-                                                            get_existing_competition_and_club_4,
                                                             get_clubs,
                                                             get_competitions,
                                                             purchasing_places_more_than_available):
@@ -382,11 +381,11 @@ def test_purchasing_places_over_available_status_code_error(mocker,
 
     client.post('/showSummary', data=get_existing_mail)
 
-    client.get(url_for(endpoint='book',
-                       competition=get_existing_competition_and_club_4['competition'],
-                       club=get_existing_competition_and_club_4['club']))
-
     purchasing_data = purchasing_places_more_than_available
+
+    client.get(url_for(endpoint='book',
+                       competition=purchasing_data['competition'],
+                       club=purchasing_data['club']))
 
     client_response = client.post('/purchasePlaces', data=purchasing_data)
 
@@ -395,7 +394,6 @@ def test_purchasing_places_over_available_status_code_error(mocker,
 def test_purchasing_places_over_available_returns_sorry(mocker,
                                                         client,
                                                         get_existing_mail,
-                                                        get_existing_competition_and_club_4,
                                                         purchasing_places_more_than_available,
                                                         get_clubs,
                                                         get_competitions):
@@ -404,11 +402,12 @@ def test_purchasing_places_over_available_returns_sorry(mocker,
 
     client.post('/showSummary', data=get_existing_mail)
 
-    client.get(url_for(endpoint='book',
-                       competition=get_existing_competition_and_club_4['competition'],
-                       club=get_existing_competition_and_club_4['club']))
-
     purchasing_data = purchasing_places_more_than_available
+
+    client.get(url_for(endpoint='book',
+                       competition=purchasing_data['competition'],
+                       club=purchasing_data['club']))
+
     the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
     club_points = the_club['points']
 
@@ -418,3 +417,23 @@ def test_purchasing_places_over_available_returns_sorry(mocker,
     assert f"Welcome, {the_club["email"]} " in data
     assert "Sorry, there are not enough places available for this competition." in data
     assert f"Points available: {club_points}" in data
+
+def test_purchasing_places_sold_out_status_code_error(mocker,
+                                                      client,
+                                                      get_existing_mail,
+                                                      get_existing_competition_and_club_4,
+                                                      get_clubs,
+                                                      get_competitions):
+
+    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
+
+    client.post('/showSummary', data=get_existing_mail)
+
+    client_response = client.get(url_for(endpoint='book',
+                       competition=get_existing_competition_and_club_4['competition'],
+                       club=get_existing_competition_and_club_4['club']))
+
+    data = client_response.data.decode('utf-8')
+
+    assert client_response.status_code == 403
+    assert "Sorry, this competition is sold out. Booking not possible." in data

--- a/unit_tests/test_app.py
+++ b/unit_tests/test_app.py
@@ -162,7 +162,8 @@ def test_good_purchasing_places_returns_summary_page(mocker, client, get_existin
           f'{the_club_name_utf8}">Book Places</a>\n'
           f'</li>')
 
-    assert "Great-booking complete!" in data
+    assert (f"Great! Booking of {purchasing_data['places']} places for "
+            f"{purchasing_data['competition']} competition complete!") in data
     assert f"Welcome, {the_club["email"]} " in data
     assert li in all_li_str
     assert f"Points available: {new_points}" in data
@@ -207,6 +208,7 @@ def test_purchasing_places_not_enough_points_returns_sorry(mocker,
     client_response = client.post('/purchasePlaces', data=get_inconsistent_purchasing_data)
     data = client_response.data.decode('utf-8')
 
+    assert f"Welcome, {the_club["email"]} " in data
     assert "Sorry, you do not have enough points to purchase." in data
     assert f"Points available: {the_club['points']}" in data
 
@@ -252,6 +254,7 @@ def test_purchasing_places_over_12_places_returns_sorry(mocker,
     client_response = client.post('/purchasePlaces', data=purchasing_data)
     data = client_response.data.decode('utf-8')
 
+    assert f"Welcome, {the_club["email"]} " in data
     assert "Sorry, you are not allow to purchase more than 12 places for this competition." in data
     assert f"Points available: {club_points}" in data
 
@@ -278,6 +281,7 @@ def test_purchasing_places_over_12_cumulative_places_returns_sorry(mocker,
     client_response = client.post('/purchasePlaces', data=purchasing_data)
     data = client_response.data.decode('utf-8')
 
+    assert f"Welcome, {the_club["email"]} " in data
     assert "Sorry, you are not allow to purchase more than 12 places for this competition." in data
     assert f"Points available: {club_points}" in data
 
@@ -326,6 +330,7 @@ def test_purchasing_places_negative_number_returns_sorry(mocker,
     client_response = client.post('/purchasePlaces', data=purchasing_data)
     data = client_response.data.decode('utf-8')
 
+    assert f"Welcome, {the_club["email"]} " in data
     assert "Sorry, you should type a positive number." in data
     assert f"Points available: {club_points}" in data
 
@@ -364,3 +369,52 @@ def test_purchasing_places_past_competitions_returns_sorry(mocker,
     data = client_response.data.decode('utf-8')
 
     assert "Sorry, this competition is outdated. Booking not possible." in data
+
+def test_purchasing_places_over_available_status_code_error(mocker,
+                                                            client,
+                                                            get_existing_mail,
+                                                            get_existing_competition_and_club_4,
+                                                            get_clubs,
+                                                            get_competitions,
+                                                            purchasing_places_more_than_available):
+
+    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
+
+    client.post('/showSummary', data=get_existing_mail)
+
+    client.get(url_for(endpoint='book',
+                       competition=get_existing_competition_and_club_4['competition'],
+                       club=get_existing_competition_and_club_4['club']))
+
+    purchasing_data = purchasing_places_more_than_available
+
+    client_response = client.post('/purchasePlaces', data=purchasing_data)
+
+    assert client_response.status_code == 403
+
+def test_purchasing_places_over_available_returns_sorry(mocker,
+                                                        client,
+                                                        get_existing_mail,
+                                                        get_existing_competition_and_club_4,
+                                                        purchasing_places_more_than_available,
+                                                        get_clubs,
+                                                        get_competitions):
+
+    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
+
+    client.post('/showSummary', data=get_existing_mail)
+
+    client.get(url_for(endpoint='book',
+                       competition=get_existing_competition_and_club_4['competition'],
+                       club=get_existing_competition_and_club_4['club']))
+
+    purchasing_data = purchasing_places_more_than_available
+    the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
+    club_points = the_club['points']
+
+    client_response = client.post('/purchasePlaces', data=purchasing_data)
+    data = client_response.data.decode('utf-8')
+
+    assert f"Welcome, {the_club["email"]} " in data
+    assert "Sorry, there are not enough places available for this competition." in data
+    assert f"Points available: {club_points}" in data

--- a/unit_tests/test_app.py
+++ b/unit_tests/test_app.py
@@ -1,439 +1,382 @@
+import pytest
+import server
+
 from bs4 import BeautifulSoup
 from flask import url_for
 
-import server
 
-def patch_clubs_and_competitions(mocker, get_clubs, get_competitions):
-    mocker.patch('server.clubs', get_clubs)
-    mocker.patch('server.competitions', get_competitions)
+class TestApp:
 
-def test_index_status_code_ok(client):
-    client_response = client.get('/')
-    assert client_response.status_code == 200
+    @pytest.fixture(autouse=True)
+    def setup(self, mocker, get_clubs, get_competitions):
+        mocker.patch('server.clubs', get_clubs)
+        mocker.patch('server.competitions', get_competitions)
 
-def test_index_return_welcome(client):
-    client_response = client.get('/')
-    data = client_response.data.decode('utf-8')
+        mocker.patch('server.save_clubs')
+        mocker.patch('server.save_competitions')
 
-    assert "Welcome to the GUDLFT Registration Portal!" in data
-    assert "Please enter your secretary email to continue:" in data
-    assert "Email:" in data
+    @staticmethod
+    def test_index_status_code_ok(client):
+        client_response = client.get('/')
+        assert client_response.status_code == 200
 
-def test_index_mail_authentication_ok(get_existing_mail, get_clubs, mocker, client):
-    mocker.patch('server.clubs', get_clubs)
-    client_response = client.post('/showSummary', data=get_existing_mail)
-    assert client_response.status_code == 200
+    @staticmethod
+    def test_index_return_welcome(client):
+        client_response = client.get('/')
+        data = client_response.data.decode('utf-8')
 
-def test_index_mail_authentication_returns_summary(mocker, client, get_existing_mail, get_clubs):
-    mocker.patch('server.clubs', get_clubs)
-    client_response = client.post('/showSummary', data=get_existing_mail)
-    data = client_response.data.decode('utf-8')
+        assert "Welcome to the GUDLFT Registration Portal!" in data
+        assert "Please enter your secretary email to continue:" in data
+        assert "Email:" in data
 
-    assert "Welcome, kate@shelifts.co.uk" in data
-    assert "Spring Festival" in data
-    assert "Fall Classic" in data
-    assert "Points available: 12" in data
+    @staticmethod
+    def test_index_mail_authentication_ok(get_existing_mail, mocker, client):
+        client_response = client.post('/showSummary', data=get_existing_mail)
+        assert client_response.status_code == 200
 
-def test_index_mail_authentication_fail(mocker, client, get_unexisting_mail, get_clubs):
-    mocker.patch('server.clubs', get_clubs)
-    client_response = client.post('/showSummary', data=get_unexisting_mail)
-    data = client_response.data.decode('utf-8')
-    assert client_response.status_code == 404
-    assert "Sorry, that email was not found." in data
+    @staticmethod
+    def test_index_mail_authentication_returns_summary(client, get_existing_mail):
+        client_response = client.post('/showSummary', data=get_existing_mail)
+        data = client_response.data.decode('utf-8')
 
-def test_summary_logout_redirect_status_code_ok(mocker, client, get_existing_mail, get_clubs):
-    mocker.patch('server.clubs', get_clubs)
-    client.post('/showSummary', data=get_existing_mail)
-    logout_response = client.get('/logout')
-    assert logout_response.status_code == 302
+        assert "Welcome, kate@shelifts.co.uk" in data
+        assert "Spring Festival" in data
+        assert "Fall Classic" in data
+        assert "Points available: 12" in data
 
-def test_summary_logout_redirect_returns_welcome(mocker, client, get_existing_mail, get_clubs):
-    mocker.patch('server.clubs', get_clubs)
-    client.post('/showSummary', data=get_existing_mail)
+    @staticmethod
+    def test_index_mail_authentication_fail(client, get_unexisting_mail):
+        client_response = client.post('/showSummary', data=get_unexisting_mail)
+        data = client_response.data.decode('utf-8')
+        assert client_response.status_code == 404
+        assert "Sorry, that email was not found." in data
 
-    logout_response = client.get('/logout')
-    soup = BeautifulSoup(logout_response.data.decode(), features="html.parser")
-    url = soup.find_all('a')[0].get('href')
-    redirect_response = client.get(url, follow_redirects=True)
+    @staticmethod
+    def test_summary_logout_redirect_status_code_ok(client, get_existing_mail):
+        client.post('/showSummary', data=get_existing_mail)
+        logout_response = client.get('/logout')
+        assert logout_response.status_code == 302
 
-    assert redirect_response.status_code == 200
-    data = redirect_response.data.decode('utf-8')
+    @staticmethod
+    def test_summary_logout_redirect_returns_welcome(client, get_existing_mail):
+        client.post('/showSummary', data=get_existing_mail)
 
-    assert "Welcome to the GUDLFT Registration Portal!" in data
-    assert "Please enter your secretary email to continue:" in data
-    assert "Email:" in data
+        logout_response = client.get('/logout')
+        soup = BeautifulSoup(logout_response.data.decode(), features="html.parser")
+        url = soup.find_all('a')[0].get('href')
+        redirect_response = client.get(url, follow_redirects=True)
 
-def test_booking_status_code_ok(mocker,
-                                client,
-                                get_existing_mail,
-                                get_existing_competition_and_club,
-                                get_clubs,
-                                get_competitions):
+        assert redirect_response.status_code == 200
+        data = redirect_response.data.decode('utf-8')
 
-    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
+        assert "Welcome to the GUDLFT Registration Portal!" in data
+        assert "Please enter your secretary email to continue:" in data
+        assert "Email:" in data
 
-    client.post('/showSummary', data=get_existing_mail)
+    @staticmethod
+    def test_booking_status_code_ok(client,
+                                    get_existing_mail,
+                                    get_existing_competition_and_club):
 
-    client_response = client.get(url_for(endpoint='book',
-                                  competition=get_existing_competition_and_club['competition'],
-                                  club=get_existing_competition_and_club['club']))
+        client.post('/showSummary', data=get_existing_mail)
 
-    assert client_response.status_code == 200
+        client_response = client.get(url_for(endpoint='book',
+                                      competition=get_existing_competition_and_club['competition'],
+                                      club=get_existing_competition_and_club['club']))
 
-def test_booking_return_festival_page_booking(mocker,
-                                              client,
-                                              get_existing_mail,
-                                              get_existing_competition_and_club,
-                                              get_clubs,
-                                              get_competitions):
+        assert client_response.status_code == 200
 
-    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
+    @staticmethod
+    def test_booking_return_festival_page_booking(client,
+                                                  get_existing_mail,
+                                                  get_existing_competition_and_club):
 
-    client.post('/showSummary', data=get_existing_mail)
+        client.post('/showSummary', data=get_existing_mail)
 
-    client_response = client.get(url_for(endpoint='book',
-                                  competition=get_existing_competition_and_club['competition'],
-                                  club=get_existing_competition_and_club['club']))
-    data = client_response.data.decode('utf-8')
-    assert "Spring Festival" in data
-    assert "Places available: " in data
-    assert "How many places?" in data
+        client_response = client.get(url_for(endpoint='book',
+                                      competition=get_existing_competition_and_club['competition'],
+                                      club=get_existing_competition_and_club['club']))
+        data = client_response.data.decode('utf-8')
+        assert "Spring Festival" in data
+        assert "Places available: " in data
+        assert "How many places?" in data
 
-def test_good_purchasing_places_status_code_ok(mocker,
-                                               client,
-                                               get_existing_mail,
-                                               get_existing_competition_and_club,
-                                               get_consistent_purchasing_data,
-                                               get_clubs,
-                                               get_competitions):
+    @staticmethod
+    def test_good_purchasing_places_status_code_ok(client,
+                                                   get_existing_mail,
+                                                   get_existing_competition_and_club,
+                                                   get_consistent_purchasing_data):
 
-    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
+        client.post('/showSummary', data=get_existing_mail)
+        client.get(url_for(endpoint='book',
+                           competition=get_existing_competition_and_club['competition'],
+                           club=get_existing_competition_and_club['club']))
 
-    client.post('/showSummary', data=get_existing_mail)
-    client.get(url_for(endpoint='book',
-                       competition=get_existing_competition_and_club['competition'],
-                       club=get_existing_competition_and_club['club']))
+        client_response = client.post('/purchasePlaces', data=get_consistent_purchasing_data)
 
-    mocker.patch('server.save_clubs')
-    mocker.patch('server.save_competitions')
+        assert client_response.status_code == 200
 
-    client_response = client.post('/purchasePlaces', data=get_consistent_purchasing_data)
+    @staticmethod
+    def test_good_purchasing_places_returns_summary_page(client,
+                                                         get_existing_mail,
+                                                         get_consistent_purchasing_data):
 
-    assert client_response.status_code == 200
+        client.post('/showSummary', data=get_existing_mail)
 
-def test_good_purchasing_places_returns_summary_page(mocker, client, get_existing_mail, get_clubs,
-                                                     get_consistent_purchasing_data,
-                                                     get_competitions):
+        purchasing_data = get_consistent_purchasing_data
+        the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
+        the_competition =[competition for competition in server.competitions
+                          if competition["name"] == purchasing_data['competition']][0]
 
-    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
+        client.get(url_for(endpoint='book',
+                           competition=the_competition['name'],
+                           club=the_club['name']))
 
-    client.post('/showSummary', data=get_existing_mail)
+        club_points = the_club['points']
+        competition_places = the_competition['number_of_places']
 
-    purchasing_data = get_consistent_purchasing_data
-    the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
-    the_competition =[competition for competition in server.competitions
-                      if competition["name"] == purchasing_data['competition']][0]
+        client_response = client.post('/purchasePlaces', data=purchasing_data)
+        data = client_response.data.decode('utf-8')
 
-    client.get(url_for(endpoint='book',
-                       competition=the_competition['name'],
-                       club=the_club['name']))
+        new_points = int(club_points) - int(purchasing_data['places'])
+        new_competition_places = int(competition_places) - int(purchasing_data['places'])
 
-    club_points = the_club['points']
-    competition_places = the_competition['number_of_places']
+        soup = BeautifulSoup(data, features="html.parser")
+        all_li_str = [str(li) for li in soup.find_all('li')]
+        the_club_name_utf8 = "%20".join(the_club['name'].split())
+        the_competition_name_utf8 = "%20".join(the_competition['name'].split())
+        li = (f'<li>\n'
+              f'            {the_competition["name"]}<br/>\n'
+              f'            Date: 2026-07-27 10:00:00\n'
+              f'            Number of Places: {new_competition_places}\n            \n'
+              f'            <a href="/book/{the_competition_name_utf8}/'
+              f'{the_club_name_utf8}">Book Places</a>\n'
+              f'</li>')
 
-    mocker.patch('server.save_clubs')
-    mocker.patch('server.save_competitions')
+        assert (f"Great! Booking of {purchasing_data['places']} places for "
+                f"{purchasing_data['competition']} competition complete!") in data
+        assert f"Welcome, {the_club["email"]} " in data
+        assert li in all_li_str
+        assert f"Points available: {new_points}" in data
 
-    client_response = client.post('/purchasePlaces', data=purchasing_data)
-    data = client_response.data.decode('utf-8')
+    @staticmethod
+    def test_purchasing_places_not_enough_points_status_code_error(client,
+                                                                   get_existing_mail_2,
+                                                                   get_existing_competition_and_club_2,
+                                                                   get_inconsistent_purchasing_data):
 
-    new_points = int(club_points) - int(purchasing_data['places'])
-    new_competition_places = int(competition_places) - int(purchasing_data['places'])
+        client.post('/showSummary', data=get_existing_mail_2)
+        client.get(url_for(endpoint='book',
+                           competition=get_existing_competition_and_club_2['competition'],
+                           club=get_existing_competition_and_club_2['club']))
 
-    soup = BeautifulSoup(data, features="html.parser")
-    all_li_str = [str(li) for li in soup.find_all('li')]
-    the_club_name_utf8 = "%20".join(the_club['name'].split())
-    the_competition_name_utf8 = "%20".join(the_competition['name'].split())
-    li = (f'<li>\n'
-          f'            {the_competition["name"]}<br/>\n'
-          f'            Date: 2026-07-27 10:00:00\n'
-          f'            Number of Places: {new_competition_places}\n            \n'
-          f'            <a href="/book/{the_competition_name_utf8}/'
-          f'{the_club_name_utf8}">Book Places</a>\n'
-          f'</li>')
+        client_response = client.post('/purchasePlaces', data=get_inconsistent_purchasing_data)
 
-    assert (f"Great! Booking of {purchasing_data['places']} places for "
-            f"{purchasing_data['competition']} competition complete!") in data
-    assert f"Welcome, {the_club["email"]} " in data
-    assert li in all_li_str
-    assert f"Points available: {new_points}" in data
+        assert client_response.status_code == 403
 
-def test_purchasing_places_not_enough_points_status_code_error(mocker,
-                                                               client,
+    @staticmethod
+    def test_purchasing_places_not_enough_points_returns_sorry(client,
                                                                get_existing_mail_2,
                                                                get_existing_competition_and_club_2,
-                                                               get_inconsistent_purchasing_data,
-                                                               get_clubs,
-                                                               get_competitions):
+                                                               get_inconsistent_purchasing_data):
 
-    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
+        client.post('/showSummary', data=get_existing_mail_2)
+        client.get(url_for(endpoint='book',
+                           competition=get_existing_competition_and_club_2['competition'],
+                           club=get_existing_competition_and_club_2['club']))
 
-    client.post('/showSummary', data=get_existing_mail_2)
-    client.get(url_for(endpoint='book',
-                       competition=get_existing_competition_and_club_2['competition'],
-                       club=get_existing_competition_and_club_2['club']))
+        the_club = [club for club in server.clubs
+                    if club["name"] == get_existing_competition_and_club_2['club']][0]
 
-    client_response = client.post('/purchasePlaces', data=get_inconsistent_purchasing_data)
+        client_response = client.post('/purchasePlaces', data=get_inconsistent_purchasing_data)
+        data = client_response.data.decode('utf-8')
 
-    assert client_response.status_code == 403
+        assert f"Welcome, {the_club["email"]} " in data
+        assert "Sorry, you do not have enough points to purchase." in data
+        assert f"Points available: {the_club['points']}" in data
 
-def test_purchasing_places_not_enough_points_returns_sorry(mocker,
-                                                           client,
-                                                           get_existing_mail_2,
-                                                           get_existing_competition_and_club_2,
-                                                           get_inconsistent_purchasing_data,
-                                                           get_clubs,
-                                                           get_competitions):
+    @staticmethod
+    def test_purchasing_places_over_12_places_status_code_error(client,
+                                                                get_existing_mail,
+                                                                get_existing_competition_and_club,
+                                                                purchasing_over_12_places):
 
-    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
+        client.post('/showSummary', data=get_existing_mail)
 
-    client.post('/showSummary', data=get_existing_mail_2)
-    client.get(url_for(endpoint='book',
-                       competition=get_existing_competition_and_club_2['competition'],
-                       club=get_existing_competition_and_club_2['club']))
+        client.get(url_for(endpoint='book',
+                           competition=get_existing_competition_and_club['competition'],
+                           club=get_existing_competition_and_club['club']))
 
-    the_club = [club for club in server.clubs
-                if club["name"] == get_existing_competition_and_club_2['club']][0]
+        client_response = client.post('/purchasePlaces', data=purchasing_over_12_places)
 
-    client_response = client.post('/purchasePlaces', data=get_inconsistent_purchasing_data)
-    data = client_response.data.decode('utf-8')
+        assert client_response.status_code == 403
 
-    assert f"Welcome, {the_club["email"]} " in data
-    assert "Sorry, you do not have enough points to purchase." in data
-    assert f"Points available: {the_club['points']}" in data
-
-def test_purchasing_places_over_12_places_status_code_error(mocker,
-                                                            client,
+    @staticmethod
+    def test_purchasing_places_over_12_places_returns_sorry(client,
                                                             get_existing_mail,
-                                                            get_existing_competition_and_club,
-                                                            purchasing_over_12_places,
-                                                            get_clubs,
-                                                            get_competitions):
+                                                            purchasing_over_12_places):
 
-    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
+        client.post('/showSummary', data=get_existing_mail)
 
-    client.post('/showSummary', data=get_existing_mail)
+        purchasing_data = purchasing_over_12_places
 
-    client.get(url_for(endpoint='book',
-                       competition=get_existing_competition_and_club['competition'],
-                       club=get_existing_competition_and_club['club']))
+        client.get(url_for(endpoint='book',
+                           competition=purchasing_data['competition'],
+                           club=purchasing_data['club']))
 
-    client_response = client.post('/purchasePlaces', data=purchasing_over_12_places)
+        the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
+        club_points = the_club['points']
 
-    assert client_response.status_code == 403
+        client_response = client.post('/purchasePlaces', data=purchasing_data)
+        data = client_response.data.decode('utf-8')
 
-def test_purchasing_places_over_12_places_returns_sorry(mocker,
-                                                        client,
-                                                        get_existing_mail,
-                                                        purchasing_over_12_places,
-                                                        get_clubs,
-                                                        get_competitions):
+        assert f"Welcome, {the_club["email"]} " in data
+        assert "Sorry, you are not allow to purchase more than 12 places for this competition." in data
+        assert f"Points available: {club_points}" in data
 
-    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
+    @staticmethod
+    def test_purchasing_places_over_12_cumulative_places_returns_sorry(client,
+                                                                       get_existing_mail,
+                                                                       purchasing_13_cumulative_places):
 
-    client.post('/showSummary', data=get_existing_mail)
+        client.post('/showSummary', data=get_existing_mail)
 
-    purchasing_data = purchasing_over_12_places
+        purchasing_data = purchasing_13_cumulative_places
 
-    client.get(url_for(endpoint='book',
-                       competition=purchasing_data['competition'],
-                       club=purchasing_data['club']))
+        client.get(url_for(endpoint='book',
+                           competition=purchasing_data['competition'],
+                           club=purchasing_data['club']))
 
-    the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
-    club_points = the_club['points']
+        the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
+        club_points = the_club['points']
 
-    client_response = client.post('/purchasePlaces', data=purchasing_data)
-    data = client_response.data.decode('utf-8')
+        client_response = client.post('/purchasePlaces', data=purchasing_data)
+        data = client_response.data.decode('utf-8')
 
-    assert f"Welcome, {the_club["email"]} " in data
-    assert "Sorry, you are not allow to purchase more than 12 places for this competition." in data
-    assert f"Points available: {club_points}" in data
+        assert f"Welcome, {the_club["email"]} " in data
+        assert "Sorry, you are not allow to purchase more than 12 places for this competition." in data
+        assert f"Points available: {club_points}" in data
 
-def test_purchasing_places_over_12_cumulative_places_returns_sorry(mocker,
-                                                                   client,
-                                                                   get_existing_mail,
-                                                                   purchasing_13_cumulative_places,
-                                                                   get_clubs,
-                                                                   get_competitions):
+    @staticmethod
+    def test_purchasing_places_negative_number_status_code_error(client,
+                                                                 get_existing_mail,
+                                                                 purchasing_with_negative_places):
 
-    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
+        client.post('/showSummary', data=get_existing_mail)
 
-    client.post('/showSummary', data=get_existing_mail)
+        purchasing_data = purchasing_with_negative_places
 
-    purchasing_data = purchasing_13_cumulative_places
+        client.get(url_for(endpoint='book',
+                           competition=purchasing_data['competition'],
+                           club=purchasing_data['club']))
 
-    client.get(url_for(endpoint='book',
-                       competition=purchasing_data['competition'],
-                       club=purchasing_data['club']))
+        client_response = client.post('/purchasePlaces', data=purchasing_data)
 
-    the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
-    club_points = the_club['points']
+        assert client_response.status_code == 403
 
-    client_response = client.post('/purchasePlaces', data=purchasing_data)
-    data = client_response.data.decode('utf-8')
-
-    assert f"Welcome, {the_club["email"]} " in data
-    assert "Sorry, you are not allow to purchase more than 12 places for this competition." in data
-    assert f"Points available: {club_points}" in data
-
-def test_purchasing_places_negative_number_status_code_error(mocker,
-                                                             client,
+    @staticmethod
+    def test_purchasing_places_negative_number_returns_sorry(client,
                                                              get_existing_mail,
-                                                             get_clubs,
-                                                             purchasing_with_negative_places,
-                                                             get_competitions):
+                                                             purchasing_with_negative_places):
 
-    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
+        client.post('/showSummary', data=get_existing_mail)
 
-    client.post('/showSummary', data=get_existing_mail)
+        purchasing_data = purchasing_with_negative_places
 
-    purchasing_data = purchasing_with_negative_places
+        client.get(url_for(endpoint='book',
+                           competition=purchasing_data['competition'],
+                           club=purchasing_data['club']))
 
-    client.get(url_for(endpoint='book',
-                       competition=purchasing_data['competition'],
-                       club=purchasing_data['club']))
+        the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
+        club_points = the_club['points']
 
-    client_response = client.post('/purchasePlaces', data=purchasing_data)
+        client_response = client.post('/purchasePlaces', data=purchasing_data)
+        data = client_response.data.decode('utf-8')
 
-    assert client_response.status_code == 403
+        assert f"Welcome, {the_club["email"]} " in data
+        assert "Sorry, you should type a positive number." in data
+        assert f"Points available: {club_points}" in data
 
-def test_purchasing_places_negative_number_returns_sorry(mocker,
-                                                         client,
-                                                         get_existing_mail,
-                                                         purchasing_with_negative_places,
-                                                         get_clubs,
-                                                         get_competitions):
+    @staticmethod
+    def test_purchasing_places_past_competitions_status_code_error(client,
+                                                                   get_existing_mail,
+                                                                   get_existing_competition_and_club_3):
 
-    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
+        client.post('/showSummary', data=get_existing_mail)
 
-    client.post('/showSummary', data=get_existing_mail)
+        client_response = client.get(url_for(endpoint='book',
+                                      competition=get_existing_competition_and_club_3['competition'],
+                                      club=get_existing_competition_and_club_3['club']))
 
-    purchasing_data = purchasing_with_negative_places
+        assert client_response.status_code == 403
 
-    client.get(url_for(endpoint='book',
-                       competition=purchasing_data['competition'],
-                       club=purchasing_data['club']))
-
-    the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
-    club_points = the_club['points']
-
-    client_response = client.post('/purchasePlaces', data=purchasing_data)
-    data = client_response.data.decode('utf-8')
-
-    assert f"Welcome, {the_club["email"]} " in data
-    assert "Sorry, you should type a positive number." in data
-    assert f"Points available: {club_points}" in data
-
-def test_purchasing_places_past_competitions_status_code_error(mocker,
-                                                               client,
+    @staticmethod
+    def test_purchasing_places_past_competitions_returns_sorry(client,
                                                                get_existing_mail,
-                                                               get_existing_competition_and_club_3,
-                                                               get_clubs,
-                                                               get_competitions):
+                                                               get_existing_competition_and_club_3):
 
-    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
+        client.post('/showSummary', data=get_existing_mail)
 
-    client.post('/showSummary', data=get_existing_mail)
+        client_response = client.get(url_for(endpoint='book',
+                           competition=get_existing_competition_and_club_3['competition'],
+                           club=get_existing_competition_and_club_3['club']))
 
-    client_response = client.get(url_for(endpoint='book',
-                                  competition=get_existing_competition_and_club_3['competition'],
-                                  club=get_existing_competition_and_club_3['club']))
+        data = client_response.data.decode('utf-8')
 
-    assert client_response.status_code == 403
+        assert "Sorry, this competition is outdated. Booking not possible." in data
 
-def test_purchasing_places_past_competitions_returns_sorry(mocker,
-                                                           client,
-                                                           get_existing_mail,
-                                                           get_existing_competition_and_club_3,
-                                                           get_clubs,
-                                                           get_competitions):
+    @staticmethod
+    def test_purchasing_places_over_available_status_code_error(client,
+                                                                get_existing_mail,
+                                                                purchasing_places_more_than_available):
 
-    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
+        client.post('/showSummary', data=get_existing_mail)
 
-    client.post('/showSummary', data=get_existing_mail)
+        purchasing_data = purchasing_places_more_than_available
 
-    client_response = client.get(url_for(endpoint='book',
-                       competition=get_existing_competition_and_club_3['competition'],
-                       club=get_existing_competition_and_club_3['club']))
+        client.get(url_for(endpoint='book',
+                           competition=purchasing_data['competition'],
+                           club=purchasing_data['club']))
 
-    data = client_response.data.decode('utf-8')
+        client_response = client.post('/purchasePlaces', data=purchasing_data)
 
-    assert "Sorry, this competition is outdated. Booking not possible." in data
+        assert client_response.status_code == 403
 
-def test_purchasing_places_over_available_status_code_error(mocker,
-                                                            client,
+    @staticmethod
+    def test_purchasing_places_over_available_returns_sorry(client,
                                                             get_existing_mail,
-                                                            get_clubs,
-                                                            get_competitions,
                                                             purchasing_places_more_than_available):
 
-    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
+        client.post('/showSummary', data=get_existing_mail)
 
-    client.post('/showSummary', data=get_existing_mail)
+        purchasing_data = purchasing_places_more_than_available
 
-    purchasing_data = purchasing_places_more_than_available
+        client.get(url_for(endpoint='book',
+                           competition=purchasing_data['competition'],
+                           club=purchasing_data['club']))
 
-    client.get(url_for(endpoint='book',
-                       competition=purchasing_data['competition'],
-                       club=purchasing_data['club']))
+        the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
+        club_points = the_club['points']
 
-    client_response = client.post('/purchasePlaces', data=purchasing_data)
+        client_response = client.post('/purchasePlaces', data=purchasing_data)
+        data = client_response.data.decode('utf-8')
 
-    assert client_response.status_code == 403
+        assert f"Welcome, {the_club["email"]} " in data
+        assert "Sorry, there are not enough places available for this competition." in data
+        assert f"Points available: {club_points}" in data
 
-def test_purchasing_places_over_available_returns_sorry(mocker,
-                                                        client,
-                                                        get_existing_mail,
-                                                        purchasing_places_more_than_available,
-                                                        get_clubs,
-                                                        get_competitions):
+    @staticmethod
+    def test_purchasing_places_sold_out_status_code_error(client,
+                                                          get_existing_mail,
+                                                          get_existing_competition_and_club_4):
 
-    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
+        client.post('/showSummary', data=get_existing_mail)
 
-    client.post('/showSummary', data=get_existing_mail)
+        client_response = client.get(url_for(endpoint='book',
+                           competition=get_existing_competition_and_club_4['competition'],
+                           club=get_existing_competition_and_club_4['club']))
 
-    purchasing_data = purchasing_places_more_than_available
+        data = client_response.data.decode('utf-8')
 
-    client.get(url_for(endpoint='book',
-                       competition=purchasing_data['competition'],
-                       club=purchasing_data['club']))
-
-    the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
-    club_points = the_club['points']
-
-    client_response = client.post('/purchasePlaces', data=purchasing_data)
-    data = client_response.data.decode('utf-8')
-
-    assert f"Welcome, {the_club["email"]} " in data
-    assert "Sorry, there are not enough places available for this competition." in data
-    assert f"Points available: {club_points}" in data
-
-def test_purchasing_places_sold_out_status_code_error(mocker,
-                                                      client,
-                                                      get_existing_mail,
-                                                      get_existing_competition_and_club_4,
-                                                      get_clubs,
-                                                      get_competitions):
-
-    patch_clubs_and_competitions(mocker, get_clubs, get_competitions)
-
-    client.post('/showSummary', data=get_existing_mail)
-
-    client_response = client.get(url_for(endpoint='book',
-                       competition=get_existing_competition_and_club_4['competition'],
-                       club=get_existing_competition_and_club_4['club']))
-
-    data = client_response.data.decode('utf-8')
-
-    assert client_response.status_code == 403
-    assert "Sorry, this competition is sold out. Booking not possible." in data
+        assert client_response.status_code == 403
+        assert "Sorry, this competition is sold out. Booking not possible." in data

--- a/unit_tests/test_app.py
+++ b/unit_tests/test_app.py
@@ -202,7 +202,7 @@ def test_purchasing_places_over_12_places_status_code_error(mocker,
                                                             client,
                                                             get_existing_mail,
                                                             get_existing_competition_and_club,
-                                                            purchasing_data_over_12_places,
+                                                            purchasing_over_12_places,
                                                             get_clubs):
     mocker.patch('server.clubs', get_clubs)
 
@@ -211,7 +211,7 @@ def test_purchasing_places_over_12_places_status_code_error(mocker,
                        competition=get_existing_competition_and_club['competition'],
                        club=get_existing_competition_and_club['club']))
 
-    response = client.post('/purchasePlaces', data=purchasing_data_over_12_places)
+    response = client.post('/purchasePlaces', data=purchasing_over_12_places)
 
     assert response.status_code == 403
 
@@ -219,7 +219,7 @@ def test_purchasing_places_over_12_places_returns_sorry(mocker,
                                                         client,
                                                         get_existing_mail,
                                                         get_existing_competition_and_club,
-                                                        purchasing_data_over_12_places,
+                                                        purchasing_over_12_places,
                                                         get_clubs):
     mocker.patch('server.clubs', get_clubs)
 
@@ -229,7 +229,31 @@ def test_purchasing_places_over_12_places_returns_sorry(mocker,
                        competition=get_existing_competition_and_club['competition'],
                        club=get_existing_competition_and_club['club']))
 
-    purchasing_data = purchasing_data_over_12_places
+    purchasing_data = purchasing_over_12_places
+    the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
+    club_points = the_club['points']
+
+    response = client.post('/purchasePlaces', data=purchasing_data)
+    data = response.data.decode('utf-8')
+
+    assert "Sorry, you are not allow to purchase more than 12 places for this competition." in data
+    assert f"Points available: {club_points}" in data
+
+def test_purchasing_places_over_12_cumulative_places_returns_sorry(mocker,
+                                                                   client,
+                                                                   get_existing_mail,
+                                                                   get_existing_competition_and_club,
+                                                                   purchasing_13_cumulative_places,
+                                                                   get_clubs):
+    mocker.patch('server.clubs', get_clubs)
+
+    client.post('/showSummary', data=get_existing_mail)
+
+    client.get(url_for(endpoint='book',
+                       competition=get_existing_competition_and_club['competition'],
+                       club=get_existing_competition_and_club['club']))
+
+    purchasing_data = purchasing_13_cumulative_places
     the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
     club_points = the_club['points']
 
@@ -244,7 +268,7 @@ def test_purchasing_places_negative_number_status_code_error(mocker,
                                                              get_existing_mail,
                                                              get_existing_competition_and_club,
                                                              get_clubs,
-                                                             purchasing_data_with_negative_places):
+                                                             purchasing_with_negative_places):
 
     mocker.patch('server.clubs', get_clubs)
 
@@ -254,7 +278,7 @@ def test_purchasing_places_negative_number_status_code_error(mocker,
                        competition=get_existing_competition_and_club['competition'],
                        club=get_existing_competition_and_club['club']))
 
-    purchasing_data = purchasing_data_with_negative_places
+    purchasing_data = purchasing_with_negative_places
 
     response = client.post('/purchasePlaces', data=purchasing_data)
 
@@ -264,7 +288,7 @@ def test_purchasing_places_negative_number_returns_sorry(mocker,
                                                          client,
                                                          get_existing_mail,
                                                          get_existing_competition_and_club,
-                                                         purchasing_data_with_negative_places,
+                                                         purchasing_with_negative_places,
                                                          get_clubs):
     mocker.patch('server.clubs', get_clubs)
 
@@ -274,7 +298,7 @@ def test_purchasing_places_negative_number_returns_sorry(mocker,
                        competition=get_existing_competition_and_club['competition'],
                        club=get_existing_competition_and_club['club']))
 
-    purchasing_data = purchasing_data_with_negative_places
+    purchasing_data = purchasing_with_negative_places
     the_club = [club for club in server.clubs if club["name"] == purchasing_data['club']][0]
     club_points = the_club['points']
 

--- a/unit_tests/test_app.py
+++ b/unit_tests/test_app.py
@@ -5,7 +5,8 @@ from unit_tests.conftest import (client, get_existing_mail, get_existing_mail_2,
                                  get_unexisting_mail, get_existing_competition_and_club,
                                  get_existing_competition_and_club_2,
                                  get_consistent_purchasing_data, get_inconsistent_purchasing_data,
-                                 get_inconsistent_purchasing_data_over_12_places)
+                                 get_inconsistent_purchasing_data_over_12_places,
+                                 get_inconsistent_purchasing_data_with_negative_places)
 
 from server import clubs, competitions
 
@@ -132,7 +133,8 @@ def test_good_purchasing_places_returns_summary_page(client):
           f'            {the_competition["name"]}<br/>\n'
           f'            Date: 2020-03-27 10:00:00\n'
           f'            Number of Places: {new_competition_places}\n            \n'
-          f'            <a href="/book/{the_competition_name_utf8}/{the_club_name_utf8}">Book Places</a>\n'
+          f'            <a href="/book/{the_competition_name_utf8}/'
+          f'{the_club_name_utf8}">Book Places</a>\n'
           f'</li>')
 
     assert "Great-booking complete!" in data
@@ -203,4 +205,36 @@ def test_purchasing_places_with_over_12_places_returns_sorry(client):
     data = response.data.decode('utf-8')
 
     assert "Sorry, you are not allow to purchase more than 12 places." in data
+    assert f"Points available: {club_points}" in data
+
+def test_purchasing_places_with_negative_number_status_code_error(client):
+    mail_data = get_existing_mail()
+    client.post('/showSummary', data=mail_data)
+    competition_and_club_data = get_existing_competition_and_club()
+    client.get(url_for(endpoint='book',
+                       competition=competition_and_club_data['competition'],
+                       club=competition_and_club_data['club']))
+
+    purchasing_data = get_inconsistent_purchasing_data_with_negative_places()
+
+    response = client.post('/purchasePlaces', data=purchasing_data)
+
+    assert response.status_code == 403
+
+def test_purchasing_places_with_negative_number_returns_sorry(client):
+    mail_data = get_existing_mail()
+    client.post('/showSummary', data=mail_data)
+    competition_and_club_data = get_existing_competition_and_club()
+    client.get(url_for(endpoint='book',
+                       competition=competition_and_club_data['competition'],
+                       club=competition_and_club_data['club']))
+
+    purchasing_data = get_inconsistent_purchasing_data_with_negative_places()
+    the_club = [club for club in clubs if club["name"] == purchasing_data['club']][0]
+    club_points = the_club['points']
+
+    response = client.post('/purchasePlaces', data=purchasing_data)
+    data = response.data.decode('utf-8')
+
+    assert "Sorry, you should type a positive number." in data
     assert f"Points available: {club_points}" in data

--- a/unit_tests/test_app.py
+++ b/unit_tests/test_app.py
@@ -130,7 +130,7 @@ def test_good_purchasing_places_returns_summary_page(mocker, client, get_existin
                        club=the_club['name']))
 
     club_points = the_club['points']
-    competition_places = the_competition['numberOfPlaces']
+    competition_places = the_competition['number_of_places']
 
     mocker.patch('server.save_clubs')
     mocker.patch('server.save_competitions')

--- a/unit_tests/test_app.py
+++ b/unit_tests/test_app.py
@@ -185,4 +185,22 @@ def test_purchasing_places_with_over_12_places_status_code_error(client):
 
     response = client.post('/purchasePlaces', data=purchasing_data)
 
-    assert response.status_code == 200
+    assert response.status_code == 403
+
+def test_purchasing_places_with_over_12_places_returns_sorry(client):
+    mail_data = get_existing_mail()
+    client.post('/showSummary', data=mail_data)
+    competition_and_club_data = get_existing_competition_and_club()
+    client.get(url_for(endpoint='book',
+                       competition=competition_and_club_data['competition'],
+                       club=competition_and_club_data['club']))
+
+    purchasing_data = get_inconsistent_purchasing_data_over_12_places()
+    the_club = [club for club in clubs if club["name"] == purchasing_data['club']][0]
+    club_points = the_club['points']
+
+    response = client.post('/purchasePlaces', data=purchasing_data)
+    data = response.data.decode('utf-8')
+
+    assert "Sorry, you are not allow to purchase more than 12 places." in data
+    assert f"Points available: {club_points}" in data

--- a/unit_tests/test_app.py
+++ b/unit_tests/test_app.py
@@ -1,0 +1,169 @@
+from bs4 import BeautifulSoup
+from flask import url_for
+
+from unit_tests.conftest import (client, get_existing_mail, get_existing_mail_2,
+                                 get_unexisting_mail, get_existing_competition_and_club,
+                                 get_existing_competition_and_club_2,
+                                 get_consistent_purchasing_data, get_inconsistent_purchasing_data,
+                                 get_inconsistent_purchasing_data_over_12_places)
+
+from server import clubs, competitions
+
+def test_index_status_code_ok(client):
+    response = client.get('/')
+    assert response.status_code == 200
+
+def test_index_return_welcome(client):
+    response = client.get('/')
+    data = response.data.decode('utf-8')
+
+    assert "Welcome to the GUDLFT Registration Portal!" in data
+    assert "Please enter your secretary email to continue:" in data
+    assert "Email:" in data
+
+def test_index_mail_authentication_ok(client):
+    mail_data = get_existing_mail()
+    response = client.post('/showSummary', data=mail_data)
+    assert response.status_code == 200
+
+def test_index_mail_authentication_return_summary(client):
+    mail_data = get_existing_mail()
+    response = client.post('/showSummary', data=mail_data)
+    data = response.data.decode('utf-8')
+
+    assert "Welcome, kate@shelifts.co.uk" in data
+    assert "Spring Festival" in data
+    assert "Fall Classic" in data
+    assert "Points available: 15" in data
+
+def test_index_mail_authentication_fail(client):
+    mail_data = get_unexisting_mail()
+    response = client.post('/showSummary', data=mail_data)
+    assert response.status_code == 404
+    assert "Sorry, that email was not found." in response.data.decode('utf-8')
+
+def test_summary_logout_redirect_status_code_ok(client):
+    mail_data = get_existing_mail()
+    client.post('/showSummary', data=mail_data)
+    logout_response = client.get('/logout')
+    assert logout_response.status_code == 302
+
+def test_summary_logout_redirect_return_welcome(client):
+    mail_data = get_existing_mail()
+    client.post('/showSummary', data=mail_data)
+
+    logout_response = client.get('/logout')
+    soup = BeautifulSoup(logout_response.data.decode(), features="html.parser")
+    url = soup.find_all('a')[0].get('href')
+    redirect_response = client.get(url, follow_redirects=True)
+
+    assert redirect_response.status_code == 200
+    data = redirect_response.data.decode('utf-8')
+
+    assert "Welcome to the GUDLFT Registration Portal!" in data
+    assert "Please enter your secretary email to continue:" in data
+    assert "Email:" in data
+
+def test_booking_status_code_ok(client):
+    mail_data = get_existing_mail()
+    client.post('/showSummary', data=mail_data)
+
+    competition_and_club_data = get_existing_competition_and_club()
+    response = client.get(url_for(endpoint='book',
+                                  competition=competition_and_club_data['competition'],
+                                  club=competition_and_club_data['club']))
+
+    assert response.status_code == 200
+
+def test_booking_return_festival_page_booking(client):
+    mail_data = get_existing_mail()
+    client.post('/showSummary', data=mail_data)
+
+    competition_and_club_data = get_existing_competition_and_club()
+    response = client.get(url_for(endpoint='book',
+                                  competition=competition_and_club_data['competition'],
+                                  club=competition_and_club_data['club']))
+    data = response.data.decode('utf-8')
+    assert "Spring Festival" in data
+    assert "Places available: " in data
+    assert "How many places?" in data
+
+def test_good_purchasing_places_status_code_ok(client):
+    mail_data = get_existing_mail()
+    client.post('/showSummary', data=mail_data)
+    competition_and_club_data = get_existing_competition_and_club()
+    client.get(url_for(endpoint='book',
+                       competition=competition_and_club_data['competition'],
+                       club=competition_and_club_data['club']))
+
+    purchasing_data = get_consistent_purchasing_data()
+
+    response = client.post('/purchasePlaces', data=purchasing_data)
+
+    assert response.status_code == 200
+
+def test_good_purchasing_places_return_summary_page(client):
+    mail_data = get_existing_mail()
+    client.post('/showSummary', data=mail_data)
+
+    purchasing_data = get_consistent_purchasing_data()
+    the_club = [club for club in clubs if club["name"] == purchasing_data['club']][0]
+    the_competition =[competition for competition in competitions
+                      if competition["name"] == purchasing_data['competition']][0]
+
+    client.get(url_for(endpoint='book',
+                       competition=the_competition['name'],
+                       club=the_club['name']))
+
+    club_points = the_club['points']
+    competition_places = the_competition['numberOfPlaces']
+
+    response = client.post('/purchasePlaces', data=purchasing_data)
+    data = response.data.decode('utf-8')
+
+    new_points = int(club_points) - int(purchasing_data['places'])
+    new_competition_places = int(competition_places) - int(purchasing_data['places'])
+
+    soup = BeautifulSoup(data, features="html.parser")
+    all_li_str = [str(li) for li in soup.find_all('li')]
+    the_club_name_utf8 = "%20".join(the_club['name'].split())
+    the_competition_name_utf8 = "%20".join(the_competition['name'].split())
+    li = (f'<li>\n'
+          f'            {the_competition["name"]}<br/>\n'
+          f'            Date: 2020-03-27 10:00:00\n'
+          f'            Number of Places: {new_competition_places}\n            \n'
+          f'            <a href="/book/{the_competition_name_utf8}/{the_club_name_utf8}">Book Places</a>\n'
+          f'</li>')
+
+    assert "Great-booking complete!" in data
+    assert f"Welcome, {the_club["email"]} " in data
+    assert li in all_li_str
+    assert f"Points available: {new_points}" in data
+
+def test_purchasing_places_fail_with_not_enough_points(client):
+    mail_data = get_existing_mail_2()
+    client.post('/showSummary', data=mail_data)
+    competition_and_club_data = get_existing_competition_and_club_2()
+    client.get(url_for(endpoint='book',
+                       competition=competition_and_club_data['competition'],
+                       club=competition_and_club_data['club']))
+
+    purchasing_data = get_inconsistent_purchasing_data()
+
+    response = client.post('/purchasePlaces', data=purchasing_data)
+
+    assert response.status_code == 403
+
+def test_purchasing_places_fails_with_over_12_places(client):
+    mail_data = get_existing_mail()
+    client.post('/showSummary', data=mail_data)
+    competition_and_club_data = get_existing_competition_and_club()
+    client.get(url_for(endpoint='book',
+                       competition=competition_and_club_data['competition'],
+                       club=competition_and_club_data['club']))
+
+    purchasing_data = get_inconsistent_purchasing_data_over_12_places()
+
+    response = client.post('/purchasePlaces', data=purchasing_data)
+
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- The club is able to signup and log in with mail and password

## Feature
### `server.py`
- Updated routes to log in with mail and password.
- Added new routes to sign up, to see club profile and to change password.
- Returns the `welcome` template with success message if the authentication succeed or error message else.

### Templates
- Used flash messages in template to inform user.
- Added new templates for signing up and changing password, and for watching profile.

### Unit tests
- Updated tests.